### PR TITLE
Check common install locations before installing runpodctl

### DIFF
--- a/runpodctl/SKILL.md
+++ b/runpodctl/SKILL.md
@@ -17,6 +17,17 @@ Manage GPU pods, serverless endpoints, templates, volumes, and models.
 
 ## Install
 
+Before installing, check if runpodctl is already available:
+
+```bash
+# Check PATH first, then common install locations
+which runpodctl 2>/dev/null || ls ~/.local/bin/runpodctl 2>/dev/null || ls ~/bin/runpodctl 2>/dev/null
+```
+
+If found outside PATH, add it: `export PATH="$HOME/.local/bin:$HOME/bin:$PATH"`
+
+If not installed:
+
 ```bash
 # Any platform (official installer)
 curl -sSL https://cli.runpod.net | bash


### PR DESCRIPTION
## Summary
- Adds a detection step to `runpodctl/SKILL.md` that checks `~/.local/bin` and `~/bin` before attempting a fresh install
- Fixes an issue where agents would reinstall runpodctl because `which runpodctl` fails when the binary is installed outside of PATH (e.g. via the manual tar.gz method)
- Shows how to add the install directory to PATH if the binary is found but not accessible

## Context
Ran into this firsthand — runpodctl was installed at `~/bin/runpodctl` but the agent couldn't find it with `which`, so it went through the entire install flow again unnecessarily.

## Test plan
- [ ] Verify the detection snippet finds runpodctl in `~/.local/bin` and `~/bin`
- [ ] Verify agents skip the install step when runpodctl is already present

🤖 Generated with [Claude Code](https://claude.com/claude-code)