### PR TITLE
feat: add --network-volume-id to pod/serverless create flags

### DIFF
--- a/runpodctl/SKILL.md
+++ b/runpodctl/SKILL.md
@@ -73,7 +73,7 @@ runpodctl pod delete <pod-id>                         # Delete pod (aliases: rm,
 **List flags:** `--all` / `-a`, `--status`, `--since`, `--created-after`, `--name`, `--compute-type`
 **Get flags:** `--include-machine`, `--include-network-volume`
 
-**Create flags:** `--template-id` (required if no `--image`), `--image` (required if no `--template-id`), `--name`, `--gpu-id`, `--gpu-count`, `--compute-type`, `--ssh` (default true), `--container-disk-in-gb`, `--volume-in-gb`, `--volume-mount-path`, `--ports`, `--env`, `--cloud-type`, `--data-center-ids`, `--global-networking`, `--public-ip`
+**Create flags:** `--template-id` (required if no `--image`), `--image` (required if no `--template-id`), `--name`, `--gpu-id`, `--gpu-count`, `--compute-type`, `--ssh` (default true), `--container-disk-in-gb`, `--volume-in-gb`, `--volume-mount-path`, `--network-volume-id`, `--ports`, `--env`, `--cloud-type`, `--data-center-ids`, `--global-networking`, `--public-ip`
 
 ### Serverless (alias: sls)
 
@@ -87,7 +87,7 @@ runpodctl serverless delete <endpoint-id>             # Delete endpoint
 
 **List flags:** `--include-template`, `--include-workers`
 **Update flags:** `--name`, `--workers-min`, `--workers-max`, `--idle-timeout`, `--scaler-type` (QUEUE_DELAY or REQUEST_COUNT), `--scaler-value`
-**Create flags:** `--name`, `--template-id`, `--gpu-id`, `--gpu-count`, `--compute-type`, `--workers-min`, `--workers-max`, `--data-center-ids`
+**Create flags:** `--name`, `--template-id`, `--gpu-id`, `--gpu-count`, `--compute-type`, `--workers-min`, `--workers-max`, `--network-volume-id`, `--data-center-ids`
 
 ### Templates (alias: tpl)
 


### PR DESCRIPTION
## Summary

- adds `--network-volume-id` to pod create flags in skill docs
- adds `--network-volume-id` to serverless create flags in skill docs

Syncs skill with runpod/runpodctl#259 (closes runpod/runpodctl#256)

## Test plan

- [ ] verify skill loads correctly with updated flag lists