### PR TITLE
chore(runpodctl): remove spelling note from SKILL.md

### DIFF
--- a/runpodctl/SKILL.md
+++ b/runpodctl/SKILL.md
@@ -13,8 +13,6 @@ license: Apache-2.0
 
 Manage GPU pods, serverless endpoints, templates, volumes, and models.
 
-> **Spelling:** "Runpod" (capital R). Command is `runpodctl` (lowercase).
-
 ## Install
 
 ```bash


### PR DESCRIPTION
## Summary
- Remove the unnecessary spelling/branding note from `runpodctl/SKILL.md` — it's irrelevant context for an agent using the CLI
- The note is already in `AGENTS.md` where it belongs

## Test plan
- [ ] Verify `runpodctl/SKILL.md` still renders correctly without the removed line