### PR TITLE
feat(runpodctl): document --model-reference (model cache) + add eval scenarios

### DIFF
--- a/runpodctl/SKILL.md
+++ b/runpodctl/SKILL.md
@@ -125,11 +125,14 @@ runpodctl serverless get <endpoint-id>                # Get endpoint details
 runpodctl serverless create --name "x" --template-id "tpl_abc"  # Create from template
 runpodctl serverless create --name "x" --hub-id <listing-id>    # Create from hub repo
 runpodctl serverless create --hub-id <id> --env MODEL_NAME=my-model  # Override hub env defaults
+runpodctl serverless create --template-id <id> --gpu-id "NVIDIA GeForce RTX 4090" --model-reference https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct:main  # Attach & cache a HF model (template + GPU only)
 runpodctl serverless update <endpoint-id> --workers-max 5       # Update endpoint
 runpodctl serverless delete <endpoint-id>             # Delete endpoint
 ```
 
 **Create from hub:** `--hub-id` resolves the hub listing, extracts the build image and config (GPU IDs, container disk, env vars), creates an inline template, and deploys. Accepts both SERVERLESS and POD listing types. GPU IDs and env var defaults from the hub config are included automatically; override with `--gpu-id` and `--env`.
+
+**Model cache (`--model-reference`):** Attach a Hugging Face model to the endpoint by full URL with a ref, e.g. `https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct:main` (the trailing `:main` is the branch/tag/revision). Runpod caches the model on the host in the default Hugging Face cache directory (`/runpod-volume/huggingface-cache/hub/`), so the worker loads it directly — no need to bake the model into the image or attach a network volume. The flag is repeatable, so you can attach multiple models, and uses the standard HF cache path, so anything that already reads the Hugging Face cache (Transformers, vLLM, etc.) picks it up automatically. Only valid with `--template-id` (not `--hub-id`) and `--compute-type GPU`. Requires runpodctl v2.4.0+.
 
 For exact serverless flags, run `runpodctl serverless <action> --help`.
 

--- a/runpodctl/evals/cpu-pod-create.eval.md
+++ b/runpodctl/evals/cpu-pod-create.eval.md
@@ -1,0 +1,19 @@
+# Create a CPU-only pod
+
+## Prompt
+
+Create a CPU-only pod for lightweight file preprocessing using the image
+`ubuntu:22.04`. Give me the exact command.
+
+## Expected behavior
+
+The agent should:
+
+1. Use `runpodctl pod create` with `--compute-type cpu`
+2. Pass `--image ubuntu:22.04`
+3. NOT pass any GPU flags (`--gpu-id`, `--gpu-count`) — they don't belong on a CPU pod
+
+## Assertions
+
+- Runs `runpodctl pod create --compute-type cpu --image ubuntu:22.04`
+- Does NOT include `--gpu-id` or `--gpu-count`

--- a/runpodctl/evals/hub-deploy-serverless.eval.md
+++ b/runpodctl/evals/hub-deploy-serverless.eval.md
@@ -1,0 +1,31 @@
+# Deploy a vLLM serverless worker from the Runpod Hub
+
+## Prompt
+
+Deploy the vLLM serverless worker from the Runpod Hub. Use an available GPU, and
+have it scale from 0 up to 2 workers. Give me the exact command(s).
+
+## Expected behavior
+
+The agent should:
+
+1. Find the hub listing id with `runpodctl hub search vllm`
+2. Create the endpoint with `runpodctl serverless create --hub-id <id> --workers-min 0 --workers-max 2`
+3. Handle the GPU correctly (this is the easy thing to get wrong):
+   - Preferably omit `--gpu-id` and let the hub config's default GPU apply, OR
+   - If specifying `--gpu-id`, use a GPU **pool ID** (e.g. `AMPERE_48`, `ADA_24`, `HOPPER_141`) — NOT a display name like `"NVIDIA A40"` from `runpodctl gpu list`. On the `--hub-id` path the API rejects display names with `Invalid GPU Pool ID`.
+
+## Assertions
+
+- Finds the hub id via `runpodctl hub search vllm` (does not invent one)
+- Runs `runpodctl serverless create --hub-id <id> ...`
+- Sets `--workers-min 0` and `--workers-max 2`
+- If `--gpu-id` is passed at all, its value is a GPU pool ID (e.g. `AMPERE_48`), NOT a `gpu list` display name like `"NVIDIA A40"`
+- Does NOT pass a `gpu list` display name to `--gpu-id` on the hub path
+
+## Notes
+
+This encodes the gotcha found via live testing and tracked upstream as
+runpod/runpodctl#287: `serverless create --gpu-id` on the `--hub-id` path requires
+GPU pool IDs, while `gpu list` (and the `--help` text) surface display names. Until
+that is reconciled, the safe answer is to omit `--gpu-id` or use a pool ID.

--- a/runpodctl/evals/image-to-template-to-serverless.eval.md
+++ b/runpodctl/evals/image-to-template-to-serverless.eval.md
@@ -1,0 +1,29 @@
+# Run a custom image as a serverless endpoint (template first)
+
+## Prompt
+
+I have my own custom Docker image `myrepo/infer:latest`. I want to run it as a
+Runpod serverless endpoint that scales from 0 to 3 workers on an A40 GPU. Give me
+the exact commands.
+
+## Expected behavior
+
+The agent should:
+
+1. Recognize that serverless endpoints are created from a `--template-id` or `--hub-id`, NOT directly from a raw image
+2. First create a serverless template: `runpodctl template create --name ... --image myrepo/infer:latest --serverless`
+3. Then create the endpoint from that template id: `runpodctl serverless create --template-id <id> --workers-min 0 --workers-max 3 ...`
+4. Order the two steps correctly (template before endpoint)
+
+## Assertions
+
+- Step 1 creates a template with `runpodctl template create --image myrepo/infer:latest --serverless`
+- Step 2 creates the endpoint with `runpodctl serverless create --template-id <id-from-step-1>`
+- Sets `--workers-min 0` and `--workers-max 3`
+- Does NOT attempt `runpodctl serverless create --image ...` (no `--image` flag exists on serverless create)
+
+## Notes
+
+The template-id path is more lenient about `--gpu-id` than the hub path (it accepts
+display names like `"NVIDIA A40"`), but see hub-deploy-serverless.eval.md and
+runpod/runpodctl#287 for the pool-id inconsistency.

--- a/runpodctl/evals/pod-auto-terminate.eval.md
+++ b/runpodctl/evals/pod-auto-terminate.eval.md
@@ -1,0 +1,22 @@
+# Create a pod that auto-terminates at a datetime
+
+## Prompt
+
+Create a GPU pod from the Docker image `myorg/trainer:latest` that automatically
+terminates itself at 2026-07-01T00:00:00Z. Give me the exact command.
+
+## Expected behavior
+
+The agent should:
+
+1. Use `runpodctl pod create` with `--image myorg/trainer:latest`
+2. Use the `--terminate-after` flag with the given datetime
+3. Choose `--terminate-after` (deletes the pod) over `--stop-after` (only stops it), since the user asked for termination
+4. Recognize this flag exists rather than declaring it impossible
+
+## Assertions
+
+- Runs `runpodctl pod create --image myorg/trainer:latest ...`
+- Uses `--terminate-after 2026-07-01T00:00:00Z`
+- Does NOT use `--stop-after` for this request
+- Does NOT claim auto-termination is unsupported

--- a/runpodctl/evals/pod-from-template-with-volume.eval.md
+++ b/runpodctl/evals/pod-from-template-with-volume.eval.md
@@ -1,0 +1,22 @@
+# Create a pod from a template with a network volume
+
+## Prompt
+
+Create a GPU pod named `trainer` from template id `tmpl-1`, and attach the network
+volume with id `nv-9`. Give me the exact command.
+
+## Expected behavior
+
+The agent should:
+
+1. Use `runpodctl pod create` with `--template-id tmpl-1`
+2. Set `--name trainer`
+3. Attach the volume with `--network-volume-id nv-9`
+4. Not need any extra GPU flag, since GPU is the default compute type
+
+## Assertions
+
+- Runs `runpodctl pod create ...`
+- Uses `--template-id tmpl-1`
+- Uses `--name trainer`
+- Uses `--network-volume-id nv-9`

--- a/runpodctl/evals/pod-ssh-connect.eval.md
+++ b/runpodctl/evals/pod-ssh-connect.eval.md
@@ -1,0 +1,20 @@
+# Get SSH connection details for a running pod
+
+## Prompt
+
+I have a running pod with id `pod-xyz`. I want to SSH into it to debug a process
+interactively. What runpodctl command(s) should I use to get connected?
+
+## Expected behavior
+
+The agent should:
+
+1. Retrieve connection details with `runpodctl ssh info pod-xyz` (or `runpodctl pod get pod-xyz`)
+2. Connect using the SSH command/key those return
+3. NOT use any deprecated interactive SSH subcommand to open the session
+
+## Assertions
+
+- Uses `runpodctl ssh info pod-xyz` or `runpodctl pod get pod-xyz` to obtain host/port/key
+- Does NOT rely on a deprecated interactive `runpodctl ssh`/`exec` session command
+- Final guidance results in a usable `ssh ...` connection to the pod

--- a/runpodctl/evals/serverless-autoscale-by-requests.eval.md
+++ b/runpodctl/evals/serverless-autoscale-by-requests.eval.md
@@ -1,0 +1,21 @@
+# Update a serverless endpoint to autoscale by pending requests
+
+## Prompt
+
+Update my serverless endpoint `ep-abc123` so it autoscales based on the number of
+pending requests, triggering when there are 4 pending. Give me the exact command.
+
+## Expected behavior
+
+The agent should:
+
+1. Identify that `runpodctl serverless update <endpoint-id>` is the right command
+2. Use the v2.3 autoscaler flags `--scale-by requests` and `--scale-threshold 4`
+3. NOT use the older `--scaler-type` / `--scaler-value` flags (removed in v2.3) or values like `REQUEST_COUNT` / `QUEUE_DELAY`
+
+## Assertions
+
+- Runs `runpodctl serverless update ep-abc123 ...`
+- Sets `--scale-by requests` (strategy = pending request count)
+- Sets `--scale-threshold 4`
+- Does NOT use `--scaler-type`, `--scaler-value`, `REQUEST_COUNT`, or `QUEUE_DELAY`


### PR DESCRIPTION
## What

Two related docs/test changes for the `runpodctl` skill, rebased onto current `main`:

### 1. Document `--model-reference` (model cache)

Adds the `--model-reference` flag to the Serverless section of `runpodctl/SKILL.md` — an example line plus a **Model cache** note. Released in **runpodctl v2.4.0** (verified present in v2.4.0/v2.5.0; absent in v2.3.0).

Verified end-to-end against the live API: create attaches the model and resolves the ref (`:main` → commit SHA); persisted and retrievable via GraphQL. Documented constraints, all enforced by the CLI with clear errors:
- Only valid with `--template-id` (**not** `--hub-id`).
- GPU only (rejects `--compute-type CPU`).
- Repeatable (`stringArray`) — pass it multiple times to attach multiple models.
- Caches into the default HF cache dir `/runpod-volume/huggingface-cache/hub/`, so no image bake / network volume needed.

Known gap (not in this skill, tracked upstream): `runpodctl serverless get` does not yet surface the attached model reference, though GraphQL does.

### 2. Eval scenarios

Adds the first `runpodctl/evals/` scenarios (`*.eval.md`), following the convention introduced for the `flash` skill in #20. These turn the throwaway prompts used to evaluate #18 (live-help) vs the static-flag-list baseline into permanent, repeatable regression tests.

| File | Probes |
|------|--------|
| `serverless-autoscale-by-requests` | v2.3 `--scale-by`/`--scale-threshold` (not the removed `--scaler-type`/`--scaler-value`) |
| `pod-auto-terminate` | `--terminate-after` vs `--stop-after` |
| `pod-ssh-connect` | `ssh info`/`pod get`, not deprecated interactive SSH |
| `cpu-pod-create` | `--compute-type cpu`, no GPU flags |
| `pod-from-template-with-volume` | template + `--network-volume-id` (control) |
| `hub-deploy-serverless` | Hub deploy + **GPU pool-id gotcha** |
| `image-to-template-to-serverless` | template-first workflow for a custom image |

## Notes

- Eval format matches `flash/evals/*.eval.md`: `# Title`, `## Prompt`, `## Expected behavior`, `## Assertions`.
- Eval commands validated against live `runpodctl 2.3.0` (incl. a real create/verify/delete cycle for serverless scenarios).
- `hub-deploy-serverless` encodes the gotcha filed upstream as runpod/runpodctl#287: `serverless create --gpu-id` on the `--hub-id` path requires GPU **pool IDs** (e.g. `AMPERE_48`), not the display names `gpu list` returns.