### PR TITLE
chore(flash): align CLI docs with runpod-flash v1.17.0

### DIFF
--- a/flash/SKILL.md
+++ b/flash/SKILL.md
@@ -6,12 +6,14 @@ user-invocable: true
 
 # Runpod Flash
 
-Write code locally, test with `flash run` (dev server at localhost:8888), and flash automatically provisions and deploys to remote GPUs/CPUs in the cloud. `Endpoint` handles everything.
+Write code locally, test with `flash dev` (dev server at localhost:8888), and flash automatically provisions and deploys to remote GPUs/CPUs in the cloud. `Endpoint` handles everything.
 
 ## Setup
 
 ```bash
-pip install runpod-flash                 # requires Python >=3.10
+pip install runpod-flash                 # requires Python >=3.10,<3.14
+# or: uv tool install runpod-flash       # install as a standalone uv tool
+# or: npx skills add runpod/skills       # add the Flash skill to an agent project
 
 # auth option 1: browser-based login (saves token locally)
 flash login
@@ -19,26 +21,39 @@ flash login
 # auth option 2: API key via environment variable
 export RUNPOD_API_KEY=your_key
 
-flash init my-project                    # scaffold a new project in ./my-project
+flash init my-project                    # scaffold a new project in ./my-project (writes AGENTS.md + CLAUDE.md)
+flash update                             # update the CLI to the latest version
+flash update --version 1.16.0            # pin a specific version (-V also works)
 ```
 
 ## CLI
 
+`flash dev` is the canonical dev-server command (`flash run` still works as a hidden alias).
+
 ```bash
-flash run                                # start local dev server at localhost:8888
-flash run --auto-provision               # same, but pre-provision endpoints (no cold start)
-flash build                              # package artifact for deployment (500MB limit)
-flash build --exclude pkg1,pkg2          # exclude packages from build
+flash dev                                # start local dev server at localhost:8888
+flash dev --auto-provision               # same, but pre-provision endpoints (no cold start)
+flash dev --port 9000 --host 0.0.0.0     # custom port/host; --reload/--no-reload toggles autoreload
+flash build                              # package artifact for deployment (1500MB limit)
+flash build --exclude pkg1,pkg2          # exclude additional packages (torch is auto-excluded)
+flash build --no-deps                    # skip transitive deps; --python-version 3.11 / --output name.tar.gz
 flash deploy                             # build + deploy (auto-selects env if only one)
 flash deploy --env staging               # build + deploy to "staging" environment
 flash deploy --app my-app --env prod     # deploy a specific app to an environment
 flash deploy --preview                   # build + launch local preview in Docker
+flash deploy --no-deps --python-version 3.11  # same build flags apply to deploy
 flash env list                           # list deployment environments
 flash env create staging                 # create "staging" environment
 flash env get staging                    # show environment details + resources
 flash env delete staging                 # delete environment + tear down resources
+flash app list                           # list flash apps in your account
+flash app create my-app                  # create a flash app
+flash app get my-app                     # show an app's environments + builds
+flash app delete my-app                  # delete an app and all its resources
 flash undeploy list                      # list all active endpoints
 flash undeploy my-endpoint               # remove a specific endpoint
+flash undeploy --all                     # remove all endpoints (--interactive/-i to pick, --force/-f to skip prompts)
+flash undeploy --cleanup-stale           # remove endpoints whose code no longer exists locally
 ```
 
 ## Endpoint: Three Modes


### PR DESCRIPTION
## What

Audited `flash/SKILL.md` against **runpod/flash @ v1.17.0** (HEAD 2139c1a) and fixed the remaining drift. The SDK surface was already correct after #20 — the drift was concentrated in the **CLI** section. Every command and flag below was verified against the live `flash` CLI (`--help`).

### Fixes
- **`flash run` → `flash dev`** as the canonical dev-server command (intro + CLI). `run` is kept by the CLI as a hidden alias, noted as such. (`cli/main.py:42-43`)
- **Build size limit 500MB → 1500MB** (`core/resources/constants.py:128` `MAX_TARBALL_SIZE_MB = 1500`).
- **Added `flash app`** group: `create` / `get` / `list` / `delete` (`cli/commands/apps.py`).
- **Added `flash update`** (`--version` / `-V`) (`cli/commands/update.py`).
- **Backfilled flags**: `build`/`deploy` `--no-deps` `--output/-o` `--python-version`; `undeploy` `--all` `--interactive/-i` `--cleanup-stale` `--force/-f`; `dev` `--host` `--port/-p` `--reload/--no-reload`.
- **Setup**: Python `>=3.10,<3.14`; noted `flash init` writes `AGENTS.md` + `CLAUDE.md`; added `uv tool install runpod-flash` and `npx skills add runpod/skills` options.

### Verification
- All documented commands/flags confirmed present in the installed `flash` CLI via `--help`.
- The 5 `flash/evals/*.eval.md` scenarios are SDK-focused and contain no stale CLI references (no change needed).
- SDK surface (Endpoint constructor, GpuGroup/CpuInstanceType tables, EndpointJob, NetworkVolume, PodTemplate, payload/runsync gotchas) re-verified against v1.17.0 source — all accurate.

## Note
Supersedes the CLI portion of #22 (which targeted v1.17.0 but conflicts with #20's already-merged SDK changes). #22 can be closed once this lands.