### PR TITLE
docs(flash): clarify flash dev is a remote dev loop + autonomous agent usage

### DIFF
--- a/flash/SKILL.md
+++ b/flash/SKILL.md
@@ -6,7 +6,7 @@ user-invocable: true
 
 # Runpod Flash
 
-Write code locally, test with `flash dev` (dev server at localhost:8888), and flash automatically provisions and deploys to remote GPUs/CPUs in the cloud. `Endpoint` handles everything.
+Write code locally, iterate with `flash dev` — it runs your functions on remote Runpod GPUs/CPUs with hot-reload and live worker logs — then `flash deploy` to ship. `Endpoint` handles provisioning.
 
 ## Setup
 
@@ -17,17 +17,24 @@ pip install runpod-flash
 
 # auth option 1: browser-based login (saves token locally)
 flash login
-flash login --no-open                    # headless: print URL instead of opening a browser
-flash login --timeout 300                # max seconds to wait for browser auth (default 600)
+# headless: print URL instead of opening a browser
+flash login --no-open
+# max seconds to wait for browser auth (default 600)
+flash login --timeout 300
 
 # auth option 2: API key via environment variable
 export RUNPOD_API_KEY=your_key
 
-flash init my-project                    # scaffold a new project in ./my-project (writes AGENTS.md + CLAUDE.md)
-flash init .                             # scaffold in the current directory
-flash init my-project --force            # overwrite existing files (-f)
-flash update                             # update the CLI to the latest version
-flash update --version 1.16.0            # pin a specific version (-V also works)
+# scaffold a new project in ./my-project (writes AGENTS.md + CLAUDE.md)
+flash init my-project
+# scaffold in the current directory
+flash init .
+# overwrite existing files (-f)
+flash init my-project --force
+# update the CLI to the latest version
+flash update
+# pin a specific version (-V also works)
+flash update --version 1.16.0
 ```
 
 `flash init` writes `AGENTS.md` (+ a `CLAUDE.md` symlink). To add them to an existing project: `python -c "from runpod_flash.rules import install_agent_files; from pathlib import Path; install_agent_files(Path.cwd())"`.
@@ -37,31 +44,96 @@ flash update --version 1.16.0            # pin a specific version (-V also works
 `flash dev` is the canonical dev-server command (`flash run` still works as a hidden alias).
 
 ```bash
-flash dev                                # start local dev server at localhost:8888
-flash dev --auto-provision               # same, but pre-provision endpoints (no cold start)
-flash dev --port 9000 --host 0.0.0.0     # custom port/host; --reload/--no-reload toggles autoreload
-flash deploy                             # build + deploy (auto-selects env if only one)
-flash deploy --env staging               # build + deploy to "staging" environment
-flash deploy --app my-app --env prod     # deploy a specific app to an environment
-flash deploy --preview                   # build + launch local preview in Docker
-flash deploy --no-deps --python-version 3.11  # build flags below also apply to deploy
-flash env list                           # list deployment environments
-flash env create staging                 # create "staging" environment
-flash env get staging                    # show environment details + resources
-flash env delete staging                 # delete environment + tear down resources
-flash app list                           # list flash apps in your account
-flash app create my-app                  # create a flash app
-flash app get my-app                     # show an app's environments + builds
-flash app delete my-app                  # delete an app and all its resources
-flash undeploy list                      # list all active endpoints
-flash undeploy my-endpoint               # remove a specific endpoint
-flash undeploy --all                     # remove all endpoints (--interactive/-i to pick, --force/-f to skip prompts)
-flash undeploy --cleanup-stale           # remove endpoints whose code no longer exists locally
+# local server at :8888, but functions run on REMOTE GPU/CPU workers;
+# hot-reloads on save and streams the worker's logs live to your terminal
+flash dev
+# same, but pre-provision endpoints (no cold start on first call)
+flash dev --auto-provision
+# custom port/host; --reload/--no-reload toggles autoreload
+flash dev --port 9000 --host 0.0.0.0
+# build + deploy (auto-selects env if only one)
+flash deploy
+# build + deploy to "staging" environment
+flash deploy --env staging
+# deploy a specific app to an environment
+flash deploy --app my-app --env prod
+# build + launch local preview in Docker
+flash deploy --preview
+# build flags below also apply to deploy
+flash deploy --no-deps --python-version 3.11
+# list deployment environments
+flash env list
+# create "staging" environment
+flash env create staging
+# show environment details + resources
+flash env get staging
+# delete environment + tear down resources
+flash env delete staging
+# list flash apps in your account
+flash app list
+# create a flash app
+flash app create my-app
+# show an app's environments + builds
+flash app get my-app
+# delete an app and all its resources
+flash app delete my-app
+# list all active endpoints
+flash undeploy list
+# remove a specific endpoint
+flash undeploy my-endpoint
+# remove all endpoints (--interactive/-i to pick, --force/-f to skip prompts)
+flash undeploy --all
+# remove endpoints whose code no longer exists locally
+flash undeploy --cleanup-stale
 
-# `flash build` is build-only (no deploy) — mainly for debugging the artifact; `flash deploy` builds for you
-flash build                              # package the artifact without deploying (1500MB limit; torch auto-excluded)
-flash build --no-deps                    # build flags: --no-deps, --exclude pkg1,pkg2, --output name.tar.gz, --python-version 3.11
+# build-only (no deploy) — mainly for debugging the artifact; `flash deploy` builds for you
+# package the artifact without deploying (1500MB limit; torch auto-excluded)
+flash build
+# build flags: --no-deps, --exclude pkg1,pkg2, --output name.tar.gz, --python-version 3.11
+flash build --no-deps
 ```
+
+## Dev vs Deploy
+
+- `flash dev` — **iterate.** Local server at `:8888`, but your decorated functions
+  execute on **remote GPU/CPU workers**. Hot-reloads on save and **streams the worker's
+  logs live** to the terminal. No build/upload/deploy wait — use this the whole time you
+  develop.
+- `flash deploy` — **ship.** Builds an artifact and deploys a stable endpoint. Slow
+  (build + upload + provision); only do this once the code works under `flash dev`.
+
+`flash dev` ships **only the function body** to the worker, so a `NameError` for a
+module-level name surfaces immediately here. `flash deploy` imports the whole module and
+can mask that bug (see Gotcha #1). Develop against `flash dev` and you catch it first.
+
+## Autonomous Dev Loop (for agents)
+
+`flash dev` is a long-running foreground server — never call it as a blocking command or
+it hangs the session. Run it in the background, capture its output, and drive it with
+HTTP. This is how an agent iterates without a human watching:
+
+```bash
+# 1. start the dev server in the BACKGROUND, tee logs to a file you can read
+flash dev > /tmp/flash-dev.log 2>&1 &
+# 2. wait until the local server answers (poll the port, don't guess)
+until curl -sf http://localhost:8888/openapi.json >/dev/null 2>&1; do sleep 2; done
+# 3. call your route — this dispatches to the remote worker
+curl -s -X POST http://localhost:8888/predict -H 'content-type: application/json' -d '{"data":[1,2,3]}'
+# 4. read the REMOTE worker's live logs (cold start, model load, prints, tracebacks)
+cat /tmp/flash-dev.log
+```
+
+- Edit a handler and **save** — hot-reload re-syncs the function body automatically; just
+  re-send the request. No restart, no redeploy.
+- The remote worker's stdout/stderr (model download, CUDA init, your `print`s, full
+  tracebacks) appears in `/tmp/flash-dev.log`. **Read that file to debug** — it's the
+  live log stream the issue is about, not a local execution trace.
+- Queue-based functions are exposed by the dev server too; use `--auto-provision` to skip
+  the first-call cold start.
+- When done, stop the server: `kill %1` (or kill the background PID).
+
+In Claude Code, run step 1 with `run_in_background: true` and read the log via BashOutput
+instead of a temp file.
 
 ## Endpoint: Three Modes
 
@@ -300,7 +372,7 @@ results = await asyncio.gather(compute(a), compute(b), compute(c))
 
 ## Gotchas
 
-1. **Imports outside function** -- most common error. Everything inside the decorated function.
+1. **Only the function body ships to the worker** -- most common error. Put imports *and* any module-level constants/helpers the function uses *inside* the decorated body. `flash deploy` imports the whole module so module globals happen to work; `flash dev` ships just the body, so a module-level name raises `NameError`. A handler that works deployed can break under dev — fix it by moving everything inside.
 2. **Forgetting await** -- all decorated functions and client methods need `await`.
 3. **Missing dependencies** -- must list in `dependencies=[]`.
 4. **gpu/cpu are exclusive** -- pick one per Endpoint.

--- a/flash/SKILL.md
+++ b/flash/SKILL.md
@@ -106,34 +106,20 @@ flash build --no-deps
 module-level name surfaces immediately here. `flash deploy` imports the whole module and
 can mask that bug (see Gotcha #1). Develop against `flash dev` and you catch it first.
 
-## Autonomous Dev Loop (for agents)
+## Autonomous Dev Loop
 
-`flash dev` is a long-running foreground server — never call it as a blocking command or
-it hangs the session. Run it in the background, capture its output, and drive it with
-HTTP. This is how an agent iterates without a human watching:
+`flash dev` is a long-running server — run it in the background (don't block on it),
+capture its output, and drive it over HTTP. The captured log is the remote worker's live
+stream (cold start, model load, `print`s, tracebacks) — read it to debug.
 
 ```bash
-# 1. start the dev server in the BACKGROUND, tee logs to a file you can read
-flash dev > /tmp/flash-dev.log 2>&1 &
-# 2. wait until the local server answers (poll the port, don't guess)
-until curl -sf http://localhost:8888/openapi.json >/dev/null 2>&1; do sleep 2; done
-# 3. call your route — this dispatches to the remote worker
-curl -s -X POST http://localhost:8888/predict -H 'content-type: application/json' -d '{"data":[1,2,3]}'
-# 4. read the REMOTE worker's live logs (cold start, model load, prints, tracebacks)
-cat /tmp/flash-dev.log
+flash dev > /tmp/flash-dev.log 2>&1 &                                    # background
+until curl -sf http://localhost:8888/openapi.json >/dev/null; do sleep 2; done  # wait for ready
+curl -s localhost:8888/predict -d '{"data":[1,2,3]}'                     # dispatches to remote worker
 ```
 
-- Edit a handler and **save** — hot-reload re-syncs the function body automatically; just
-  re-send the request. No restart, no redeploy.
-- The remote worker's stdout/stderr (model download, CUDA init, your `print`s, full
-  tracebacks) appears in `/tmp/flash-dev.log`. **Read that file to debug** — it's the
-  live log stream the issue is about, not a local execution trace.
-- Queue-based functions are exposed by the dev server too; use `--auto-provision` to skip
-  the first-call cold start.
-- When done, stop the server: `kill %1` (or kill the background PID).
-
-In Claude Code, run step 1 with `run_in_background: true` and read the log via BashOutput
-instead of a temp file.
+Edit a handler and save — hot-reload re-syncs the body; just re-send the request, no
+redeploy. Add `--auto-provision` to skip the first-call cold start. `kill %1` when done.
 
 ## Endpoint: Three Modes
 

--- a/flash/SKILL.md
+++ b/flash/SKILL.md
@@ -113,13 +113,19 @@ capture its output, and drive it over HTTP. The captured log is the remote worke
 stream (cold start, model load, `print`s, tracebacks) — read it to debug.
 
 ```bash
-flash dev > /tmp/flash-dev.log 2>&1 &                                    # background
-until curl -sf http://localhost:8888/openapi.json >/dev/null; do sleep 2; done  # wait for ready
-curl -s localhost:8888/predict -d '{"data":[1,2,3]}'                     # dispatches to remote worker
+flash dev > /tmp/flash-dev.log 2>&1 &                          # background; never run it blocking
+until grep -q "flash dev  localhost:" /tmp/flash-dev.log; do sleep 2; done   # wait for startup
+URL=$(grep -o "localhost:[0-9]*" /tmp/flash-dev.log | head -1)               # actual port (8888 bumps if taken)
+curl -s "$URL/main/predict" -d '{"data": {...}}'               # dispatches to the remote worker
 ```
 
-Edit a handler and save — hot-reload re-syncs the body; just re-send the request, no
-redeploy. Add `--auto-provision` to skip the first-call cold start. `kill %1` when done.
+- **Read the real URL from the log** — flash auto-bumps the port if 8888 is in use, and
+  prints `✓ flash dev  localhost:<port>` plus the route table.
+- **Routes are namespaced by file**: `main.py`'s `/predict` is served at `/main/predict`.
+- A handler typed `def predict(data: dict)` expects the arg as a top-level field — send
+  `{"data": {...}}`, not the bare object (otherwise 422).
+- Edit a handler and save — hot-reload re-syncs the body; just re-send the request, no
+  redeploy. Add `--auto-provision` to skip the first-call cold start. `kill %1` when done.
 
 ## Endpoint: Three Modes
 

--- a/flash/evals/dev-loop-iteration.eval.md
+++ b/flash/evals/dev-loop-iteration.eval.md
@@ -1,0 +1,36 @@
+# Iterate on a flash GPU handler with live remote logs
+
+## Prompt
+
+I'm building an image-to-3D endpoint with runpod-flash and need to iterate on my GPU
+handler fast — testing each change against a real GPU worker and watching the logs. My
+handler works when I `flash deploy` it, but I want a tighter loop than re-deploying every
+time. It also just failed with `NameError: name 'VOL' is not defined`, where `VOL` is a
+constant I defined at the top of the module. How should I run this, and why is `VOL`
+failing?
+
+## Expected behavior
+
+The agent should:
+
+1. Recommend `flash dev` (not repeated `flash deploy`) as the iteration loop
+2. Explain that `flash dev` runs the function on a **remote** GPU/CPU worker (not locally)
+   while hot-reloading on save and streaming the worker's logs live
+3. Run the dev server as a **background** process (it is long-running / blocking) and read
+   its captured log output to see the remote worker's logs
+4. Explain the `NameError`: only the function body ships to the worker, so the
+   module-level `VOL` constant does not exist remotely — fix by moving it inside the
+   function body
+5. Note that `flash deploy` imports the whole module so it can mask this, while `flash dev`
+   surfaces it
+
+## Assertions
+
+- Recommends `flash dev` for the iteration loop and does NOT recommend repeated `flash deploy` for iteration
+- States that `flash dev` executes the function on a REMOTE worker, not on the local machine
+- Mentions hot-reload on save AND live/streamed worker logs
+- Runs `flash dev` as a background / non-blocking process (does NOT run it as a plain blocking command)
+- Reads the dev server's log output (file or BashOutput) to inspect the remote worker logs
+- Diagnoses the `NameError` as the module-level `VOL` not shipping to the worker (only the function body ships)
+- Fixes it by moving `VOL` inside the decorated function body
+- Notes that `flash deploy` can mask this bug while `flash dev` surfaces it

--- a/flash/evals/dev-loop-iteration.eval.md
+++ b/flash/evals/dev-loop-iteration.eval.md
@@ -1,36 +1,59 @@
-# Iterate on a flash GPU handler with live remote logs
+# Iterate on a flash GPU handler against a live remote worker
+
+> **LIVE eval.** This runs against real Runpod infrastructure — it provisions a real
+> worker and incurs cost. It is graded on what actually happened at runtime, not on what
+> the agent says it would do.
+
+## Setup
+
+- Requires `RUNPOD_API_KEY` in the environment (flash CLI authenticated, v1.17.0+).
+- Copy the fixture to a scratch dir so the graded fix does not mutate the committed
+  fixture: `cp -r flash/evals/fixtures/dev-loop /tmp/dev-loop-eval && cd /tmp/dev-loop-eval`
+  (or `git checkout flash/evals/fixtures/dev-loop` afterward).
+- The fixture's `/predict` handler references a module-level `VOL` constant, which does not
+  ship to the remote worker — it fails at runtime until moved into the function body.
 
 ## Prompt
 
-I'm building an image-to-3D endpoint with runpod-flash and need to iterate on my GPU
-handler fast — testing each change against a real GPU worker and watching the logs. My
-handler works when I `flash deploy` it, but I want a tighter loop than re-deploying every
-time. It also just failed with `NameError: name 'VOL' is not defined`, where `VOL` is a
-constant I defined at the top of the module. How should I run this, and why is `VOL`
-failing?
+Use the runpod-flash project in this directory (an image-to-3D style endpoint). The
+`/predict` route fails when it actually runs on a worker. Iterate against a **real** remote
+worker: start the dev loop, send a request, read the worker's logs, fix whatever is broken,
+and confirm a successful JSON response. I don't want to re-deploy on every change.
 
 ## Expected behavior
 
-The agent should:
+The agent should actually execute (not merely describe) the following:
 
-1. Recommend `flash dev` (not repeated `flash deploy`) as the iteration loop
-2. Explain that `flash dev` runs the function on a **remote** GPU/CPU worker (not locally)
-   while hot-reloading on save and streaming the worker's logs live
-3. Run the dev server as a **background** process (it is long-running / blocking) and read
-   its captured log output to see the remote worker's logs
-4. Explain the `NameError`: only the function body ships to the worker, so the
-   module-level `VOL` constant does not exist remotely — fix by moving it inside the
-   function body
-5. Note that `flash deploy` imports the whole module so it can mask this, while `flash dev`
-   surfaces it
+1. Recommend and use `flash dev` (not repeated `flash deploy`) for the loop, and run it as a
+   **background** process so it does not block the session.
+2. Determine the dev server's **actual** URL from its startup log rather than assuming
+   `localhost:8888` (flash bumps the port if 8888 is taken).
+3. Send a real request to the correct **file-namespaced** route (`main.py` → `/main/predict`),
+   which provisions and dispatches to the remote worker.
+4. Read the captured dev-server log to observe the **real** error from the worker.
+5. Diagnose it: only the function body ships, so module-level `VOL` is undefined remotely.
+   Fix by moving `VOL` inside the handler and rely on hot-reload (no redeploy).
+6. Re-send the request and confirm a real successful response.
+7. Undeploy everything it provisioned.
 
 ## Assertions
 
-- Recommends `flash dev` for the iteration loop and does NOT recommend repeated `flash deploy` for iteration
-- States that `flash dev` executes the function on a REMOTE worker, not on the local machine
-- Mentions hot-reload on save AND live/streamed worker logs
-- Runs `flash dev` as a background / non-blocking process (does NOT run it as a plain blocking command)
-- Reads the dev server's log output (file or BashOutput) to inspect the remote worker logs
-- Diagnoses the `NameError` as the module-level `VOL` not shipping to the worker (only the function body ships)
-- Fixes it by moving `VOL` inside the decorated function body
-- Notes that `flash deploy` can mask this bug while `flash dev` surfaces it
+- Runs `flash dev` as a background / non-blocking process (does NOT run it as a plain
+  blocking command and hang)
+- Determines the actual host:port from the dev-server output (does NOT hardcode `8888` when
+  it was bumped)
+- Sends the request to the file-namespaced route (`/main/predict`), not the bare `/predict`
+- Observes the **verbatim** runtime error `NameError: name 'VOL' is not defined` in the
+  worker's streamed logs (it is reported from the live run, not guessed)
+- Fixes the bug by moving `VOL` into the function body and re-tests via hot-reload, without
+  running `flash deploy`
+- Obtains a real **HTTP 200** whose body contains `"ok": true` (e.g.
+  `{"ok":true,"vol":"/runpod-volume/models","echo":...}`)
+- Runs `flash undeploy --all --force` (or equivalent) and confirms no endpoints remain
+
+## Cleanup
+
+- `flash undeploy --all --force` must report the provisioned endpoint deleted, and
+  `flash undeploy list` must show no endpoints.
+- The agent must only stop processes/ports it started.
+- Restore the fixture if it was edited in place: `git checkout flash/evals/fixtures/dev-loop`.

--- a/flash/evals/fixtures/dev-loop/main.py
+++ b/flash/evals/fixtures/dev-loop/main.py
@@ -1,0 +1,21 @@
+from runpod_flash import Endpoint, GpuGroup
+
+# BUG (intentional — do NOT "pre-fix" this): a module-level constant referenced
+# inside the handler. Under `flash dev` only the function body ships to the
+# remote worker, so this raises `NameError: name 'VOL' is not defined` remotely
+# until it is moved inside predict(). `flash deploy` imports the whole module and
+# masks the bug; `flash dev` surfaces it. The eval's job is to reproduce, observe
+# in the live worker logs, and fix it.
+VOL = "/runpod-volume/models"
+
+api = Endpoint(name="dev-loop-eval", gpu=GpuGroup.AMPERE_16, workers=(0, 1), dependencies=[])
+
+
+@api.post("/predict")
+async def predict(data: dict):
+    return {"ok": True, "vol": VOL, "echo": data}
+
+
+@api.get("/health")
+async def health():
+    return {"status": "ok"}


### PR DESCRIPTION
Closes #24.

## Why

`flash dev`'s "local dev server" framing read as *local execution*. In reality it runs your decorated functions on **remote GPU/CPU workers** with hot-reload and **live streamed worker logs** — the single most useful thing for iterating. The skill never said this, and never contrasted dev vs deploy, which sent the issue reporter down repeated `flash deploy` cycles + blind log polling.

## Changes

- **Intro + `flash dev` line** now state remote execution, hot-reload, and live logs.
- **New "Dev vs Deploy" section** — `flash dev` = iterate; `flash deploy` = ship.
- **New "Autonomous Dev Loop (for agents)" section** — `flash dev` is a long-running foreground server; documents backgrounding it, polling the port for readiness, driving it over HTTP, reading the remote worker's logs, and the hot-reload loop. This makes the loop usable by an agent without a human watching.
- **Generalized Gotcha #1** — *only the function body ships to the worker*. `flash deploy` imports the whole module so module-level constants happen to work; `flash dev` ships just the body, so a module-level name raises `NameError`. Deploy masks it, dev surfaces it.
- **Reformatted the CLI bash blocks** to comment-above-command, dropping the alignment whitespace (fewer wasted tokens).
- **New eval** `flash/evals/dev-loop-iteration.eval.md` covering the dev-loop workflow and the `NameError` diagnosis.

## Verification

Ran the new eval scenario against a subagent with the updated skill vs. the current `main` skill. Updated skill passes all 8 assertions. The baseline missed the key one — explaining *why* a handler works on deploy but breaks under dev (the deploy-masks-the-bug point) — and gave a muddier `NameError` mechanism. That's the gap this PR closes.