### PR TITLE
docs: rename repo references to runpod/runpod-plugins-official

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,10 +11,10 @@ agents how to manage GPU workloads across several backends and how Runpod works
 conceptually.
 
 Two install paths read the **same** `.claude-plugin/marketplace.json`:
-- **Plugin:** `/plugin marketplace add runpod/skills` then `/plugin install runpod@runpod`
+- **Plugin:** `/plugin marketplace add runpod/runpod-plugins-official` then `/plugin install runpod@runpod`
   (native, auto-updating; in Claude Code also wires the hosted MCP via
   `plugins/runpod/.mcp.json` — Codex/Gemini may need it added separately).
-- **skills.sh:** `npx skills add runpod/skills` (skills.sh reads the marketplace
+- **skills.sh:** `npx skills add runpod/runpod-plugins-official` (skills.sh reads the marketplace
   manifest and installs the declared skill paths).
 
 ## Repository layout

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ Don't add a `version` to the plugin *entry* inside `marketplace.json`'s `plugins
 
 ### Break-glass manual release (`scripts/release.sh`)
 
-The automated path needs the release-please **Action** to be permitted to write on `runpod/skills` (org setting). Until the org enables it, merging the release PR can't tag — so there's a manual path that cuts the release with **your own `gh` credentials** instead of the Action's token:
+The automated path needs the release-please **Action** to be permitted to write on `runpod/runpod-plugins-official` (org setting). Until the org enables it, merging the release PR can't tag — so there's a manual path that cuts the release with **your own `gh` credentials** instead of the Action's token:
 
 ```bash
 ./scripts/release.sh 1.1.0 --dry-run       # preview every step, change nothing

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Official Runpod Agent Skills
+# Runpod Official Plugins
 
 The **official** plugin marketplace of skills for AI agents to manage GPU workloads on Runpod —
 pods, serverless endpoints, jobs, templates, and volumes — via the Runpod MCP
@@ -17,9 +17,9 @@ Copilot, Windsurf, Cline, and 17+ other agents — all from the same manifest.
 Gemini, opencode, +more). The first line is all you need; drop any others you won't use:
 
 ```bash
-npx skills add runpod/skills                 # the skills — any agent (essential)
-curl -sSL https://cli.runpod.net | bash      # runpodctl — infra CLI (or: brew install runpod/runpodctl/runpodctl)
-uv tool install runpod-flash                 # flash — deploy your own code (optional; or: pip install runpod-flash)
+npx skills add runpod/runpod-plugins-official # the skills — any agent (essential)
+curl -sSL https://cli.runpod.net | bash       # runpodctl — infra CLI (or: brew install runpod/runpodctl/runpodctl)
+uv tool install runpod-flash                  # flash — deploy your own code (optional; or: pip install runpod-flash)
 npx @runpod/mcp-server@latest add            # hosted MCP server — guided setup, OAuth (optional)
 ```
 
@@ -51,7 +51,7 @@ Then [authenticate](#authentication).
 ### Claude Code
 
 ```
-/plugin marketplace add runpod/skills
+/plugin marketplace add runpod/runpod-plugins-official
 /plugin install runpod@runpod
 /reload-plugins
 ```
@@ -66,7 +66,7 @@ endpoints"* — it should call the MCP `list-endpoints` tool.
 ### Codex
 
 ```bash
-codex plugin marketplace add https://github.com/runpod/skills.git
+codex plugin marketplace add https://github.com/runpod/runpod-plugins-official.git
 codex /plugins        # → open the "Runpod" marketplace tab → Runpod → Install (reload if prompted)
 ```
 
@@ -88,9 +88,9 @@ Install the skills via **skills.sh** (reads the same
 [`.claude-plugin/marketplace.json`](.claude-plugin/marketplace.json)):
 
 ```bash
-npx skills add runpod/skills
+npx skills add runpod/runpod-plugins-official
 # just one skill:
-npx skills add https://github.com/runpod/skills/tree/main/plugins/runpod/skills/runpodctl
+npx skills add https://github.com/runpod/runpod-plugins-official/tree/main/plugins/runpod/skills/runpodctl
 ```
 
 Gemini can also install natively via the bundled
@@ -145,7 +145,7 @@ it up yet, force it manually:
 | --- | --- |
 | **Claude Code** | `/plugin marketplace update runpod` then `/reload-plugins` |
 | **Codex** | `codex plugin marketplace upgrade runpod` |
-| **skills.sh** | re-run `npx skills add runpod/skills` |
+| **skills.sh** | re-run `npx skills add runpod/runpod-plugins-official` |
 
 ## Uninstall
 

--- a/plugins/runpod/.claude-plugin/plugin.json
+++ b/plugins/runpod/.claude-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Runpod",
     "email": "team@runpod.io"
   },
-  "homepage": "https://github.com/runpod/skills",
-  "repository": "https://github.com/runpod/skills",
+  "homepage": "https://github.com/runpod/runpod-plugins-official",
+  "repository": "https://github.com/runpod/runpod-plugins-official",
   "license": "Apache-2.0",
   "keywords": [
     "runpod",

--- a/plugins/runpod/.codex-plugin/plugin.json
+++ b/plugins/runpod/.codex-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "Runpod",
     "email": "team@runpod.io"
   },
-  "homepage": "https://github.com/runpod/skills/tree/main/plugins/runpod",
+  "homepage": "https://github.com/runpod/runpod-plugins-official/tree/main/plugins/runpod",
   "keywords": [
     "runpod",
     "gpu",

--- a/plugins/runpod/skills/runpod-usage/reference/getting-started.md
+++ b/plugins/runpod/skills/runpod-usage/reference/getting-started.md
@@ -23,10 +23,10 @@ Nothing to install for the **hosted MCP** beyond configuring your client, and th
 **Want the Runpod tools in one go?** Copy-paste (drop any line you won't use):
 
 ```bash
-npx skills add runpod/skills                 # the skills — works with any agent
-curl -sSL https://cli.runpod.net | bash      # runpodctl — infra CLI (or: brew install runpod/runpodctl/runpodctl)
-uv tool install runpod-flash                 # flash — deploy your own code (or: pip install runpod-flash)
-npx @runpod/mcp-server@latest add            # hosted MCP server — guided setup, OAuth
+npx skills add runpod/runpod-plugins-official # the skills — works with any agent
+curl -sSL https://cli.runpod.net | bash       # runpodctl — infra CLI (or: brew install runpod/runpodctl/runpodctl)
+uv tool install runpod-flash                  # flash — deploy your own code (or: pip install runpod-flash)
+npx @runpod/mcp-server@latest add             # hosted MCP server — guided setup, OAuth
 ```
 
 Companion CLIs (`docker`, `gh`, `hf`, `aws`) are separate and OS-specific — install only the


### PR DESCRIPTION
Prep for the repo rename **runpod/skills → runpod/runpod-plugins-official**.

Updates install/marketplace references and plugin.json `homepage`/`repository` URLs across:
- README.md, AGENTS.md, CONTRIBUTING.md
- plugins/runpod/.claude-plugin/plugin.json, .codex-plugin/plugin.json
- plugins/runpod/skills/runpod-usage/reference/getting-started.md

Filesystem paths (`plugins/runpod/skills/`) are intentionally unchanged. All validation hooks pass (validate_marketplace, check_versions, check_runpod_branding, check_links).