### PR TITLE
fix(flash): scope dev-loop eval cleanup to its own endpoint

### DIFF
--- a/flash/evals/dev-loop-iteration.eval.md
+++ b/flash/evals/dev-loop-iteration.eval.md
@@ -34,7 +34,8 @@ The agent should actually execute (not merely describe) the following:
 5. Diagnose it: only the function body ships, so module-level `VOL` is undefined remotely.
    Fix by moving `VOL` inside the handler and rely on hot-reload (no redeploy).
 6. Re-send the request and confirm a real successful response.
-7. Undeploy everything it provisioned.
+7. Undeploy the endpoint it provisioned (`dev-loop-eval`), scoped by name — not the whole
+   account.
 
 ## Assertions
 
@@ -49,11 +50,14 @@ The agent should actually execute (not merely describe) the following:
   running `flash deploy`
 - Obtains a real **HTTP 200** whose body contains `"ok": true` (e.g.
   `{"ok":true,"vol":"/runpod-volume/models","echo":...}`)
-- Runs `flash undeploy --all --force` (or equivalent) and confirms no endpoints remain
+- Runs `flash undeploy dev-loop-eval --force` — scoped to the endpoint it created, NOT
+  `flash undeploy --all` (which would delete unrelated endpoints in the account) — and
+  confirms the `dev-loop-eval` endpoint is gone
 
 ## Cleanup
 
-- `flash undeploy --all --force` must report the provisioned endpoint deleted, and
-  `flash undeploy list` must show no endpoints.
+- `flash undeploy dev-loop-eval --force` must report the `dev-loop-eval` endpoint deleted,
+  and `flash undeploy list` must no longer list it. Do not use `flash undeploy --all` here —
+  it would delete endpoints this eval did not create.
 - The agent must only stop processes/ports it started.
 - Restore the fixture if it was edited in place: `git checkout flash/evals/fixtures/dev-loop`.


### PR DESCRIPTION
## Context

The `dev-loop-iteration` **live** eval (`flash/evals/dev-loop-iteration.eval.md`) runs against a real Runpod account. Its cleanup step instructed the agent to run `flash undeploy --all --force` and then asserted that `flash undeploy list` shows **no endpoints**.

> [!WARNING]
> `flash undeploy --all` deletes **every** endpoint in the account — not just the one the eval created. An agent grading this eval against a real account could tear down a user's unrelated production endpoints. The "no endpoints remain" assertion is also invalid whenever the account already has endpoints, so a correct run could be graded as a failure.

## Proposal

Scope teardown to the endpoint the fixture actually provisions (`dev-loop-eval`, from `evals/fixtures/dev-loop/main.py`):

- **Expected behavior #7** → undeploy the `dev-loop-eval` endpoint, scoped by name, not the whole account.
- **Assertion** → run `flash undeploy dev-loop-eval --force` (explicitly *not* `--all`) and confirm that endpoint is gone.
- **Cleanup** → `flash undeploy dev-loop-eval --force` reports the endpoint deleted and `flash undeploy list` no longer lists it; added explicit warnings against `--all`.

The `flash undeploy <name> --force` form is verified to exist in `runpod-flash` (positional endpoint name).

## Verified

- Reviewed the rendered diff: the only remaining `--all` mentions are the new "do NOT use `--all`" warnings (`rg -n "undeploy --all"`).
- Confirmed the fixture endpoint name is `dev-loop-eval` (`evals/fixtures/dev-loop/main.py:11`), so the scoped command targets exactly what the eval creates.
- No changes to the fixture, the prompt, or the bug-reproduction/diagnosis assertions — teardown only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)