### PR TITLE
Separate binding rules from context in agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,12 +51,11 @@ skills/runpod-usage/      conceptual knowledge ("how Runpod works") — not a to
 ```
 
 **runpod-mcp and runpodctl overlap** — both drive the same Runpod REST API for the
-same infra CRUD. The authoritative precedence rule (**capability first, environment
-second**) lives in `skills/runpod/SKILL.md`'s capability matrix: prefer runpod-mcp for
-simple structured reads/CRUD when its tools are connected, but hand off to runpodctl
-the moment an operation needs a capability MCP lacks (Hub, `send`/`receive`, SSH,
-`doctor`, models, or pod-from-template / CPU / multi-GPU), and whenever the agent is
-shell-only. Read the matrix there rather than the summary here.
+same infra CRUD. Which one wins is decided by the **capability-first, environment-second**
+precedence rule, canonical in `skills/runpod/SKILL.md`'s capability matrix (roughly: runpod-mcp
+for simple structured CRUD when connected, runpodctl the moment an op needs a capability MCP
+lacks — Hub, `send`/`receive`, SSH, `doctor`, models, pod-from-template / CPU / multi-GPU — or
+whenever the agent is shell-only). Consult the matrix there; don't rely on this summary.
 
 ## Skill file format
 
@@ -67,10 +66,9 @@ shell-only. Read the matrix there rather than the summary here.
 - `user-invocable` — set for skills a user invokes directly.
 - `compatibility`, `metadata` (author, version), `license`.
 
-The body is markdown the agent consumes. Follow **progressive disclosure**: keep
-the `SKILL.md` body small (a decision table + the 80% patterns) and push long
-tables / deep explanations into `reference/*.md` that the body links to and the
-agent opens only when needed.
+The body is markdown the agent consumes, following **progressive disclosure** (see Contributor
+rule 8): the `SKILL.md` body stays small and long tables / deep explanations live in
+`reference/*.md` that the body links to and the agent opens only when needed.
 
 ## Golden paths & evals
 
@@ -78,7 +76,7 @@ agent opens only when needed.
   They have **no `SKILL.md`**, so skills.sh never loads them as skills — they are
   acceptance scenarios/documentation. Each path's live-verification status is
   authoritative in `golden-paths/README.md`'s Status column (and restated in each
-  file) — read it there; don't summarize status here, it drifts.
+  file) — read it there.
 - Each golden-path doc uses one section template: Goal · Status · Lane(s) → When to
   use → Prerequisites → Walkthrough → Verify → Gotchas → Cost & cleanup → skill gaps.
 - Each skill's `evals/*.eval.md` are regression scenarios (Prompt / Expected
@@ -91,13 +89,15 @@ editing the repo. Each is its own checkable rule.
 
 1. **Adding a skill** — list its path in the `skills` array of
    `.claude-plugin/marketplace.json` (that array is what skills.sh resolves).
-2. **Skill `description`** — keep it to 1–2 sentences; for a skill that overlaps
-   another, name the sibling and state when to defer to it.
+2. **Skill `description`** —
+   - Keep each `description` to 1–2 sentences.
+   - If a skill overlaps another, its `description` names the sibling and states when to defer to it.
 3. **`allowed-tools`** — omit this field for knowledge-only skills.
 4. **Capability matrix** — the runpod-mcp vs runpodctl precedence rule is canonical
-   in `skills/runpod/SKILL.md`. When it changes, update `skills/runpod/SKILL.md`,
-   `skills/runpod-mcp/SKILL.md`, and `skills/runpodctl/SKILL.md` in the same change;
-   don't restate the rule elsewhere.
+   in `skills/runpod/SKILL.md`.
+   - When it changes, update `skills/runpod/SKILL.md`, `skills/runpod-mcp/SKILL.md`, and
+     `skills/runpodctl/SKILL.md` in the same change.
+   - State the rule only in `skills/runpod/SKILL.md`; do not restate it elsewhere.
 5. **Golden paths** —
    - Single approach → one file `NN-name.md`. Multiple variants → a folder
      `NN-name/` with a `README.md` (goal, "which variant?", shared schema/gotchas/cost)
@@ -105,13 +105,22 @@ editing the repo. Each is its own checkable rule.
    - Every golden-path doc follows the section template listed under *Golden paths & evals*.
    - When adding or splitting a path, update the `golden-paths/README.md` table in the
      same change.
+   - The per-path verification status is authoritative in `golden-paths/README.md`'s Status
+     column; do not restate it in AGENTS.md (it drifts).
 6. **Evals** — add or update an `evals/*.eval.md` when you add or change routing/behavior.
-7. **Releases** — never hand-bump versions. Use Conventional Commits; release-please
-   cuts the release (see `CONTRIBUTING.md` → Cutting a release).
+7. **Releases** —
+   - Never hand-bump versions; release-please cuts the release (see `CONTRIBUTING.md` →
+     Cutting a release).
+   - Use Conventional Commits.
+8. **Skill body size** — put only a decision table plus the 80% patterns in a `SKILL.md` body;
+   move long tables and deep explanations into `reference/*.md` linked from the body.
 
 ## Conventions
 
-- **Spelling:** "Runpod" (capital R). The CLI command is `runpodctl` (lowercase).
-- **Auth:** everything unifies on `RUNPOD_API_KEY`; the MCP hosted server is the
-  exception (OAuth "Sign in with Runpod"). Companion CLIs use their own creds.
+Rules:
+- **Spelling:** write "Runpod" (capital R); the CLI command is `runpodctl` (lowercase).
+
+Reference facts (not rules):
+- **Auth:** everything unifies on `RUNPOD_API_KEY`; the hosted MCP is the exception
+  (OAuth "Sign in with Runpod"). Companion CLIs use their own creds.
 - **License:** Apache-2.0.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,20 +24,23 @@ hooks/                            validation scripts
 
 1. Edit or add `plugins/runpod/skills/<name>/SKILL.md` (YAML frontmatter needs
    `name` + `description`; keep the body small and push detail into `reference/*.md`).
-2. If you **add** a skill, list its path in the `skills` array of both
-   `.claude-plugin/marketplace.json` and (for Codex) confirm it lives under the
-   plugin's `skills/` dir.
+2. When you **add** a skill:
+   - list its path in the `skills` array of `.claude-plugin/marketplace.json`;
+   - confirm the skill directory lives under the plugin's `skills/` dir (required for Codex).
 3. Add or update an `evals/*.eval.md` when you change routing or behavior.
 4. To ship the change, cut a release (see **Cutting a release** below) — don't bump
    the manifests by hand.
 
 ## Conventions
 
-- **Spelling:** "Runpod" (capital R). The CLI command is `runpodctl` (lowercase).
-- **Skills/commands are named as verbs; agents as role-nouns.**
+Rules:
+- **Spelling:** write "Runpod" (capital R); the CLI command is `runpodctl` (lowercase).
+- **Naming:** skills/commands are named as verbs; agents as role-nouns.
+
+Reference facts (not rules):
 - **License:** Apache-2.0.
-- **Auth:** everything unifies on `RUNPOD_API_KEY`; the hosted MCP is the
-  exception (OAuth). Companion CLIs use their own creds.
+- **Auth:** everything unifies on `RUNPOD_API_KEY`; the hosted MCP is the exception (OAuth).
+  Companion CLIs use their own creds.
 
 ## Commit messages
 
@@ -92,7 +95,12 @@ release-please runs on every push to `main` (`.github/workflows/release-please.y
 
 `hooks/check_versions.py` runs in CI as a drift guard and **fails the build if any of these disagree**. `scripts/bump-version.sh` does the same bump locally but is an **emergency/local fallback only** — normal releases go through release-please.
 
-Don't add a `version` to the plugin *entry* inside `marketplace.json`'s `plugins[]` — a `plugin.json` vs entry mismatch silently masks updates. And don't remove the `# x-release-please-version` annotation from a `SKILL.md` version line, or release-please will stop bumping that skill.
+**Release invariants (do not violate):**
+
+1. Never add a `version` key to a plugin *entry* in `marketplace.json`'s `plugins[]` — a
+   `plugin.json` vs entry mismatch silently masks updates.
+2. Never remove the `# x-release-please-version` annotation from a `SKILL.md` version line —
+   release-please will stop bumping that skill.
 
 ### Break-glass manual release (`scripts/release.sh`)
 
@@ -104,9 +112,14 @@ The automated path needs the release-please **Action** to be permitted to write 
 ./scripts/release.sh 1.1.0 --publish-only  # just tag current HEAD + Release (bump already merged via PR)
 ```
 
-Flags combine in any order. It prompts for confirmation before any push (skip with `--yes` in automation), warns if `HEAD` isn't `origin/main`, and is **idempotent** — safe to re-run after a partial failure; each step checks state first and a re-run resumes (it verifies any existing tag points at the intended commit rather than blindly re-tagging). Because it bumps `.release-please-manifest.json` too, release-please stays in sync — once the org enables the Action, go back to **merge the release PR** and don't run this. It's break-glass, not the default.
+Flags combine in any order. It prompts for confirmation before any push (skip with `--yes` in automation), warns if `HEAD` isn't `origin/main`, and is **idempotent** — safe to re-run after a partial failure; each step checks state first and a re-run resumes (it verifies any existing tag points at the intended commit rather than blindly re-tagging). Because it bumps `.release-please-manifest.json` too, release-please stays in sync.
 
-## Validate before pushing
+**When to use `release.sh`:** only while the org has not yet permitted the release-please Action to write on `runpod/skills`. Once it is enabled, resume merging the standing release PR and do not run this script — it's break-glass, not the default.
+
+## Validate locally (optional — CI is authoritative)
+
+Run these locally to catch failures early; CI runs the same hooks on every PR and is the
+authoritative gate.
 
 ```bash
 python3 hooks/validate_marketplace.py     # manifests + referenced paths resolve

--- a/plugins/runpod/skills/companion-clis/reference/aws.md
+++ b/plugins/runpod/skills/companion-clis/reference/aws.md
@@ -11,14 +11,15 @@ Runpod uses its own S3-compatible API, not AWS. You need a Runpod user ID and S3
 - **Access key** (`AWS_ACCESS_KEY_ID`): your Runpod user ID — found in the console under Settings > S3 API Keys, in the key description (format: `user_...`)
 - **Secret key** (`AWS_SECRET_ACCESS_KEY`): an S3 API key — generate one at Settings > S3 API Keys > Create. Shown only once; save it immediately (format: `rps_...`)
 
-> **S3 API keys are Console-only — a manual step to escalate.** There is **no**
-> `runpodctl` command and **no** REST/GraphQL endpoint to create an S3 API key or read
-> the user ID; both come from the Console (Settings > S3 API Keys). An agent cannot
-> self-provision these — if S3-API access is needed and the keys aren't already in
-> `~/.aws/credentials` / env vars, **stop and ask the user to generate them** in the
-> portal. (This differs from the regular `RUNPOD_API_KEY`, which the CLI can save.)
-> Note the AWS access key must be the Runpod **user id** (`user_...`), not the
-> `RUNPOD_API_KEY`.
+> **S3 API keys are Console-only.** There is **no** `runpodctl` command and **no**
+> REST/GraphQL endpoint to create an S3 API key or read the user ID; both come from the
+> Console (Settings > S3 API Keys), so an agent cannot self-provision them. (This differs
+> from the regular `RUNPOD_API_KEY`, which the CLI can save.) Note the AWS access key must
+> be the Runpod **user id** (`user_...`), not the `RUNPOD_API_KEY`.
+>
+> **Rule:** if an operation needs S3-API access and no S3 credentials are present in
+> `~/.aws/credentials` or env vars, stop and ask the user to generate them in the Console —
+> do not attempt to self-provision them.
 
 ```bash
 # Option 1: interactive configure (writes ~/.aws/credentials and ~/.aws/config)

--- a/plugins/runpod/skills/flash/SKILL.md
+++ b/plugins/runpod/skills/flash/SKILL.md
@@ -181,7 +181,7 @@ https://docs.runpod.io/flash/custom-docker-images
 7. **Client vs decorator** -- `image=`/`id=` = client. Otherwise = decorator.
 8. **Auto GPU switching requires workers >= 5** -- pass a list of GPU types (e.g. `gpu=[GpuGroup.ADA_24, GpuGroup.AMPERE_80]`) and set `workers=5` or higher. The platform only auto-switches GPU types based on supply when max workers is at least 5.
 9. **`runsync` timeout is 60s** -- cold starts can exceed 60s. Use `ep.runsync(data, timeout=120)` for first requests or use `ep.run()` + `job.wait()` instead.
-10. **Request body shape (raw/external HTTP callers only)** -- three rules, by endpoint type:
+10. **Request body shape (raw/external HTTP callers only)** -- match the request shape to the endpoint type:
     - **LB routes** (`@api.post(...)`): send the handler arg at the top level — `{"data": {...}}`.
     - **QB endpoints** (bare `@Endpoint`, hit via `.../run` or `.../runsync`): the worker calls
       **`handler(**job_input)`**, so the request's `input` keys must match the handler's parameter

--- a/plugins/runpod/skills/flash/SKILL.md
+++ b/plugins/runpod/skills/flash/SKILL.md
@@ -42,9 +42,13 @@ can mask that bug (see Gotcha #1). Develop against `flash dev` and you catch it 
 
 ## Autonomous Dev Loop
 
-`flash dev` is a long-running server — run it in the background (don't block on it),
-capture its output, and drive it over HTTP. The captured log is the remote worker's live
-stream (cold start, model load, `print`s, tracebacks) — read it to debug.
+`flash dev` is a long-running server. Three rules:
+- **Run it in the background** — don't block on it.
+- **Capture its output** to a log file.
+- **Drive it over HTTP.**
+
+The captured log is the remote worker's live stream (cold start, model load, `print`s,
+tracebacks) — read it to debug.
 
 ```bash
 flash dev > /tmp/flash-dev.log 2>&1 &                          # background; never run it blocking
@@ -177,9 +181,18 @@ https://docs.runpod.io/flash/custom-docker-images
 7. **Client vs decorator** -- `image=`/`id=` = client. Otherwise = decorator.
 8. **Auto GPU switching requires workers >= 5** -- pass a list of GPU types (e.g. `gpu=[GpuGroup.ADA_24, GpuGroup.AMPERE_80]`) and set `workers=5` or higher. The platform only auto-switches GPU types based on supply when max workers is at least 5.
 9. **`runsync` timeout is 60s** -- cold starts can exceed 60s. Use `ep.runsync(data, timeout=120)` for first requests or use `ep.run()` + `job.wait()` instead.
-10. **Request body shape: QB spreads input as kwargs, LB is top-level** -- Load-balanced routes (`@api.post(...)`) take the handler arg at the top level: `{"data": {...}}`. Queue-based endpoints (bare `@Endpoint`, hit via `.../run` or `.../runsync`) call the handler as **`handler(**job_input)`** — the request's `input` dict is spread as keyword arguments, so the handler's parameter names must match the input keys: a handler `def transcribe(input_data: dict)` wants `{"input": {"input_data": {...}}}`, and `def read(input: dict)` wants `{"input": {"input": {...}}}` (a mismatch fails with `got an unexpected keyword argument …`, verified 2026-07-10 via worker logs). Use `**kwargs` if the handler ignores the payload. The flash client (`ep.runsync(x)`, `api.post(...)`) hides the spreading — it's a trap for raw HTTP/external callers. See *Autonomous Dev Loop*.
-    - **Never send an empty `input`.** A QB request with `{"input": {}}` is rejected by
-      the worker SDK as `Job has missing field(s): id or input` — always include at least one key.
+10. **Request body shape (raw/external HTTP callers only)** -- three rules, by endpoint type:
+    - **LB routes** (`@api.post(...)`): send the handler arg at the top level — `{"data": {...}}`.
+    - **QB endpoints** (bare `@Endpoint`, hit via `.../run` or `.../runsync`): the worker calls
+      **`handler(**job_input)`**, so the request's `input` keys must match the handler's parameter
+      names — `def transcribe(input_data: dict)` wants `{"input": {"input_data": {...}}}`, and
+      `def read(input: dict)` wants `{"input": {"input": {...}}}`. A mismatch fails with
+      `got an unexpected keyword argument …`. Use `**kwargs` if the handler ignores the payload.
+    - **Never send an empty `input`.** A QB request with `{"input": {}}` is rejected by the
+      worker SDK as `Job has missing field(s): id or input` — always include at least one key.
+    - *Context:* the flash client (`ep.runsync(x)`, `api.post(...)`) hides the spreading, so this
+      only bites raw HTTP/external callers (mismatch behavior verified 2026-07-10 via worker logs).
+      See *Autonomous Dev Loop*.
 11. **Load a model once per worker (not per call)** -- for real inference use a class `@Endpoint` whose `__init__` loads the model once per worker (see [reference/patterns.md → Loading ML models](reference/patterns.md#loading-ml-models-warm-workers)). In function-form, reconcile with #1 by caching in a module global *inside* the body so it works under both `flash dev` and `deploy`:
     ```python
     global _MODEL

--- a/plugins/runpod/skills/runpod-mcp/SKILL.md
+++ b/plugins/runpod/skills/runpod-mcp/SKILL.md
@@ -54,8 +54,9 @@ printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocol
 
 The MCP server drives Runpod's **REST v2** internally (`RUNPOD_REST_VERSION=v2`), so it
 handles infra correctly where the **public `rest.runpod.io/v1`** control API is buggy —
-notably CPU serverless endpoints (see the runpodctl skill). Prefer MCP or `runpodctl`
-over hand-rolled `rest.runpod.io/v1` calls for creating endpoints.
+notably CPU serverless endpoints (see the runpodctl skill).
+
+**Prefer MCP or `runpodctl` over hand-rolled `rest.runpod.io/v1` calls for creating endpoints.**
 
 ## Tool surface
 

--- a/plugins/runpod/skills/runpod-usage/reference/getting-started.md
+++ b/plugins/runpod/skills/runpod-usage/reference/getting-started.md
@@ -50,12 +50,13 @@ yourself (e.g. an `Authorization: Bearer` header for a direct API call), prefer
 | **runpod-mcp (hosted)** | "Sign in with Runpod" OAuth on first connect | No key on disk. Or pass `Authorization: Bearer $RUNPOD_API_KEY`. |
 | **runpod-mcp (local)** | `RUNPOD_API_KEY` env in the MCP client config | Forwarded to the API. |
 
-Agent rule: **`export RUNPOD_API_KEY=...` is the universal non-interactive path**
-(runpodctl and flash both honor it) — the closest thing to one-step setup. The
-**hosted MCP is the exception**: it uses its own `/mcp` "Sign in with Runpod" OAuth
-(or pass the same key as an `Authorization: Bearer` header) — authing the MCP does
-not set up the CLIs, and the export does not authenticate the hosted MCP's OAuth.
-Avoid `runpodctl doctor` in automation — it prompts.
+**Rule (agents):** in automation, set the key with `export RUNPOD_API_KEY=...` (runpodctl and
+flash both honor it — the closest thing to one-step setup); never run `runpodctl doctor`, which
+prompts.
+
+Context: the **hosted MCP is the exception** — it uses its own `/mcp` "Sign in with Runpod" OAuth
+(or pass the same key as an `Authorization: Bearer` header). Authing the MCP does not set up the
+CLIs, and the export does not authenticate the hosted MCP's OAuth.
 
 ## SSH (only needed for pods you exec into)
 

--- a/plugins/runpod/skills/runpod-usage/reference/networking.md
+++ b/plugins/runpod/skills/runpod-usage/reference/networking.md
@@ -28,9 +28,10 @@ not an external port number. Key behaviors:
   connections at 100s with a `524`. For long work, return a job ID and poll, or use TCP.
 - **Public, unauthenticated** — anyone with the URL can reach the service; the Pod ID
   is obscurity, not access control, and the proxy adds no auth (same as any
-  port-forwarded service). **Rule:** when you hand a proxy URL to the user, say it's
-  public and unauthenticated; if the service handles anything sensitive, auth must be
-  implemented in the service itself (e.g. a login/token in front of it) — the platform won't.
+  port-forwarded service).
+  - **Rule:** when you hand a proxy URL to the user, state that it is public and unauthenticated.
+  - **Rule:** if the service handles anything sensitive, implement auth inside the service
+    itself (e.g. a login/token) — the platform adds none.
 - "Running" (green) in the console does not mean the service is ready; the container
   may still be starting.
 

--- a/plugins/runpod/skills/runpod/SKILL.md
+++ b/plugins/runpod/skills/runpod/SKILL.md
@@ -39,9 +39,9 @@ runpodctl user            # succeeds ⇒ a key is set and valid
 ```
 Plus, in Claude Code, `/mcp` should show `runpod` **Connected**.
 
-**Get a key — it unlocks EVERY tool; don't default to MCP OAuth.** One `RUNPOD_API_KEY`
-authenticates **runpodctl + flash + the hosted MCP** (as `--header "Authorization: Bearer
-$RUNPOD_API_KEY"`). The MCP's "Sign in with Runpod" OAuth auths the **MCP alone** — the CLIs
+**Rule: get a key first — do not default to MCP OAuth.** The reason: one `RUNPOD_API_KEY`
+unlocks every tool — it authenticates **runpodctl + flash + the hosted MCP** (as `--header
+"Authorization: Bearer $RUNPOD_API_KEY"`). The MCP's "Sign in with Runpod" OAuth auths the **MCP alone** — the CLIs
 stay blocked, so you hit a wall on any CLI-only task (Hub, `send`/`receive`, SSH, `doctor`,
 model cache/Model Repository, CPU endpoints). ⚠️ **OAuth-only is a half-setup.** If nothing's
 set up, stop and get a key, in order:
@@ -100,10 +100,14 @@ moment an op needs a flag/feature MCP doesn't expose.**
 ## Deploying a workload (the golden loop)
 
 For any "get <X> running on Runpod" task, follow the **development loop** in
-`runpod-usage/reference/development-loop.md`: decide pod vs serverless → **prefer a
-prebuilt template / Hub worker over building from scratch** → provision → set up
-(only if from-scratch) → **verify with a real request from outside** ("Running"/
-"ready" ≠ serving) → deliver → cost-guard + teardown. It branches to two sub-loops:
+`runpod-usage/reference/development-loop.md`: decide pod vs serverless → provision → set up
+(only if from-scratch) → verify → deliver → cost-guard + teardown. Two rules bind within it:
+
+- **Prefer a prebuilt template / Hub worker over building an image from scratch.**
+- **Before delivering, verify the workload with a real request from outside the pod/endpoint
+  — a "Running"/"ready" status does not mean it is serving.**
+
+It branches to two sub-loops:
 
 - **Service you open at a URL** (Ollama, ComfyUI, dev box) →
   [`runpod-usage/reference/pod-workflows.md`](../runpod-usage/reference/pod-workflows.md)

--- a/plugins/runpod/skills/runpodctl/SKILL.md
+++ b/plugins/runpod/skills/runpodctl/SKILL.md
@@ -22,14 +22,15 @@ Manage GPU pods, serverless endpoints, templates, volumes, and models.
 
 `curl -sSL https://cli.runpod.net | bash` (any platform) or `brew install runpod/runpodctl/runpodctl`. Manual binaries, Windows/Linux steps, and the version caveat (`--model-reference` + multi-volume need **v2.4.0+**): **[reference/install.md](reference/install.md)**.
 
-> **Always get on the latest runpodctl first — don't use whatever's already installed.**
-> Run `runpodctl version`, then `runpodctl update` (or reinstall from the
-> [latest release](https://github.com/runpod/runpodctl/releases)) **before doing any work**.
-> Older builds silently lack newer flags/behaviors (e.g. `--model-reference` doesn't exist
-> before v2.4.0) and produce confusing downstream errors — and the Homebrew tap can lag
-> well behind. Pin to one recent version for the whole task; **do not switch between an old
-> and a new binary mid-task** (that mid-task version flip-flop is a known failure). Verify
-> once: `runpodctl version` shows the current build before you continue.
+> Old runpodctl builds silently lack newer flags/behaviors (e.g. `--model-reference` doesn't
+> exist before v2.4.0) and produce confusing downstream errors — and the Homebrew tap can lag
+> well behind. So, before any work:
+>
+> - **Update to the latest build** — check `runpodctl version`, then run `runpodctl update`
+>   (or reinstall from the [latest release](https://github.com/runpod/runpodctl/releases)).
+> - **Pin to one recent version for the whole task.**
+> - **Never switch between an old and a new binary mid-task** (that flip-flop is a known failure).
+> - **Verify once** — `runpodctl version` shows the current build before you continue.
 
 ## Quick start
 
@@ -71,9 +72,6 @@ Before using unfamiliar commands, inspect live help first. Do not rely on this s
 
 - Use Hub when the user wants a known deployable app or worker such as vLLM, ComfyUI, Whisper, or a Runpod-maintained repo.
   - **Picking a worker:** prefer a **first-party or well-adopted, recently-released** worker on a **broad, high-availability GPU pool**. Observable signals via `runpodctl hub list`: `--owner runpod-workers` (first-party), `--order-by releasedAt`/`updatedAt` (recency), `--order-by deploys`/`stars` (adoption). Don't pin a scarce large-GPU tier a small model doesn't need.
-  - **Broken-image tell:** if deployed workers go `ready` but jobs sit `IN_QUEUE` with `inProgress: 0`, that image is broken/mis-dispatching — switch workers, don't wait it out.
-  - **Diagnosing it:** there's no first-class serverless worker-log command, so diagnose via `/health` worker counts.
-- Serverless endpoints scale to zero with `--workers-min 0` (the default) — no GPU billing while idle, only per request-second; this is the right cost posture for a request/response API.
 - **"Active worker" = minimum workers, not maximum.** If a user asks for an "active worker," they mean `--workers-min 1` (keep one worker always warm → no cold start), **not** `--workers-max 1` (that only caps the ceiling). A warm min-1 worker is ideal for development/iteration.
 - ⚠️ **A min-1 worker bills continuously, even while idle** (it defeats scale-to-zero). When you set `--workers-min 1` for dev, you **must** set it back to `--workers-min 0` (or delete the endpoint) when done — otherwise it quietly runs up cost.
 - `serverless update` has **no `--gpu-id` flag**. To change an existing endpoint's GPU pool, call `PATCH https://rest.runpod.io/v1/endpoints/<id>` with `{"gpuTypeIds":[...]}` directly.
@@ -89,6 +87,12 @@ Before using unfamiliar commands, inspect live help first. Do not rely on this s
 - Clean up paid resources after tests: delete serverless endpoints, pods, and temporary volumes created for validation.
   - **Cost guard on creation:** use `--terminate-after` (deletes the pod); `--stop-after` only *stops* it, so disk/volume keep billing.
   - **Attached volume:** to delete a network volume, remove the pod using it first.
+
+### Serverless facts (context, not rules)
+
+- **Scale-to-zero billing:** serverless endpoints scale to zero with `--workers-min 0` (the default) — no GPU billing while idle, only per request-second; this is the right cost posture for a request/response API.
+- **Broken-image tell:** if deployed workers go `ready` but jobs sit `IN_QUEUE` with `inProgress: 0`, that image is broken/mis-dispatching — switch workers, don't wait it out.
+- **Diagnosing it:** there's no first-class serverless worker-log command, so diagnose via `/health` worker counts.
 
 ## Commands
 

--- a/plugins/runpod/skills/runpodctl/SKILL.md
+++ b/plugins/runpod/skills/runpodctl/SKILL.md
@@ -91,8 +91,8 @@ Before using unfamiliar commands, inspect live help first. Do not rely on this s
 ### Serverless facts (context, not rules)
 
 - **Scale-to-zero billing:** serverless endpoints scale to zero with `--workers-min 0` (the default) — no GPU billing while idle, only per request-second; this is the right cost posture for a request/response API.
-- **Broken-image tell:** if deployed workers go `ready` but jobs sit `IN_QUEUE` with `inProgress: 0`, that image is broken/mis-dispatching — switch workers, don't wait it out.
-- **Diagnosing it:** there's no first-class serverless worker-log command, so diagnose via `/health` worker counts.
+- **Broken-image tell:** if deployed workers go `ready` but jobs sit `IN_QUEUE` with `inProgress: 0`, the image is broken/mis-dispatching — the fix is to switch to a different worker rather than wait it out.
+- **Diagnosing it:** there's no first-class serverless worker-log command, so diagnosis relies on `/health` worker counts.
 
 ## Commands
 

--- a/plugins/runpod/skills/runpodctl/reference/install.md
+++ b/plugins/runpod/skills/runpodctl/reference/install.md
@@ -19,9 +19,11 @@ Invoke-WebRequest -Uri https://github.com/runpod/runpodctl/releases/latest/downl
 
 Ensure `~/.local/bin` is on your `PATH` (add `export PATH="$HOME/.local/bin:$PATH"` to `~/.bashrc` or `~/.zshrc`).
 
-> **Update to the latest build before doing any work** — `runpodctl update` (or reinstall
-> from [GitHub releases](https://github.com/runpod/runpodctl/releases)), then confirm with
-> `runpodctl version`. Older builds silently lack newer flags (e.g. `--model-reference`
-> needs **v2.4.0+**) and cause confusing downstream errors; the Homebrew tap can lag well
-> behind. Pin one recent version for the whole task — don't flip between an old and new
-> binary mid-task.
+> Older builds silently lack newer flags (e.g. `--model-reference` needs **v2.4.0+**) and
+> cause confusing downstream errors; the Homebrew tap can lag well behind. So:
+>
+> - **Before starting work, update to the latest build** — `runpodctl update` (or reinstall
+>   from [GitHub releases](https://github.com/runpod/runpodctl/releases)), then confirm with
+>   `runpodctl version`.
+> - **Pin one recent version for the whole task** — don't flip between an old and new binary
+>   mid-task.


### PR DESCRIPTION
## Context

Audited the repo's agent-consumed instruction documents (`AGENTS.md`, `CONTRIBUTING.md`, the six `SKILL.md` files, reference docs, and manifests) with the **separating-context-from-constraints** lens. Every statement an agent reads plays one of three roles — a **binding rule**, a **load-bearing fact**, or **discretionary context** — and mixing them costs us in three ways:

- rules camouflaged as narration get dropped under long-context pressure;
- bundled obligations can't be individually checked (an agent satisfies one, misses another, with no signal);
- readers can't tell a hard requirement from negotiable flavor.

The audit produced 23 findings (4 Material, 19 Minor); the six manifests and most reference docs were already clean. This PR applies the fixes.

## What changed

All edits are **documentation-only** and **semantics-preserving** — no rule was added, dropped, strengthened, or weakened. Structural presentation only:

- **Pulled buried rules into list items** — e.g. the router's "golden loop" now surfaces *prefer-prebuilt* and *verify-with-a-real-request* as discrete rules instead of hiding them mid-arrow-chain; flash Gotcha #10's QB-vs-LB request-body rules are split out.
- **Split multi-obligation sentences into atomic rules** — runpodctl version hygiene (update / pin / never-switch / verify), several `AGENTS.md` contributor rules, the `CONTRIBUTING.md` add-skill step.
- **Surfaced silent-failure invariants** — `CONTRIBUTING.md` release invariants (don't add a `plugins[]` entry `version`; don't remove the `# x-release-please-version` annotation) are now a labeled "do not violate" block.
- **Moved facts out of rule sections** — `runpodctl` serverless facts, the `Conventions` auth/license entries in both `AGENTS.md` and `CONTRIBUTING.md`.

### One deliberate strength change (maintainer-approved)
`CONTRIBUTING.md` "Validate before pushing" → **"Validate locally (optional — CI is authoritative)"**. The local hooks + smoke test are advisory; CI runs the same hooks on every PR and is the gate.

## Audited call sites / files reviewed
`AGENTS.md`, `CONTRIBUTING.md`, `flash/SKILL.md`, `runpod/SKILL.md`, `runpod-mcp/SKILL.md`, `runpodctl/SKILL.md` (+ its `reference/install.md`), `companion-clis/reference/aws.md`, `runpod-usage/reference/{networking,getting-started}.md`.

## Verified
- All four validation hooks pass: `validate_marketplace`, `check_versions`, `check_runpod_branding`, `check_links`.
- **Codex reviewed the diff** for semantic preservation; its four catches were all incorporated before commit:
  - restored the "don't summarize golden-path status" rule (I'd removed it without re-homing it);
  - restored the "80% patterns" wording (drifted to "highest-frequency");
  - reverted a runpod-mcp *preference* I'd accidentally hardened into a *prohibition*;
  - restored the pre-update `runpodctl version` check.

> [!NOTE]
> Out of scope (separate purpose — content accuracy, not constraint separation), noted as follow-ups: the top-line manifest `description` is duplicated across 4 files; the lane list in `marketplace.json` and `gemini-extension.json` omits the `runpod-mcp` lane; `flash/SKILL.md`'s frontmatter says `@remote` but the body documents `@Endpoint`.