### PR TITLE
docs(runpod): cover LOAD_BALANCER endpoints and the v2 scaling shape

### DIFF
--- a/plugins/runpod/skills/runpod-mcp/SKILL.md
+++ b/plugins/runpod/skills/runpod-mcp/SKILL.md
@@ -66,7 +66,10 @@ use `runpodctl serverless create --compute-type CPU` for those.
 Structured tools, grouped by resource:
 
 - **Pods** — list, get, create, update, start, stop, restart, delete, stream logs.
-- **Serverless endpoints** — list, get, create, update, delete; list workers; list releases; stream worker logs. To pin a specific GPU **SKU** on an existing endpoint use `set-endpoint-gpus`; `create-endpoint`/`update-endpoint` expose only `gpuPoolIds` and can't express a SKU (`deploy-hub-repo` can pin one at deploy time via `gpuIds` exclusions).
+- **Serverless endpoints** — list, get, create, update, delete; list workers; list releases; stream worker logs.
+  - `create-endpoint` takes `endpointType: QUEUE` (default) or `LOAD_BALANCER` — see golden path 14. The routing type is fixed at creation; `update-endpoint` cannot change it.
+  - Read an endpoint's invoke URLs from `requestUrls` on the get/list reply instead of assembling them.
+  - To pin a specific GPU **SKU** on an existing endpoint use `set-endpoint-gpus`; `create-endpoint`/`update-endpoint` expose only `gpuPoolIds` and can't express a SKU (`deploy-hub-repo` can pin one at deploy time via `gpuIds` exclusions).
 - **Jobs (serverless runtime)** — run, runsync, status, stream, cancel, retry, health, purge queue.
 - **Hub** — `list-hub-repos` (public catalog of prebuilt Serverless workers and Pod templates: vLLM, ComfyUI, …) and `deploy-hub-repo`, which deploys a repo's listed release as an endpoint — the same as clicking Deploy on the Hub.
 - **Public endpoints** — `list-public-endpoints`: managed pay-per-use model APIs (text/image/video/audio) that need no deployment. Call the returned endpointId with `run-endpoint`/`runsync-endpoint`.

--- a/plugins/runpod/skills/runpod/golden-paths/13-autoscaling-tuning.md
+++ b/plugins/runpod/skills/runpod/golden-paths/13-autoscaling-tuning.md
@@ -68,8 +68,35 @@ Both are set the same way; the difference is *when* a worker gets added.
 | `--scale-by delay --scale-threshold 4` | `QUEUE_DELAY` | `4` |
 
 > runpodctl **v2.3** removed the older `--scaler-type REQUEST_COUNT / --scaler-value`
-> flags — use `--scale-by` + `--scale-threshold`. (The REST/GraphQL fields are still named
-> `scalerType`/`scalerValue`.)
+> flags — use `--scale-by` + `--scale-threshold`. (In **v1** REST and GraphQL the stored
+> fields are still named `scalerType`/`scalerValue`.)
+
+**On v2 REST the same two knobs are shaped differently.** `GET /v2/serverless/<id>` returns
+a scaler-specific object instead of a shared `value`, and the idle timeout sits under
+`workers`:
+
+| Meaning | v1 REST / GraphQL | v2 REST |
+| --- | --- | --- |
+| aggressive, on in-flight requests | `scalerType: REQUEST_COUNT`, `scalerValue: 1` | `scaling: {type: "REQUEST_COUNT", requestCount: 1}` |
+| lazy, on queue wait | `scalerType: QUEUE_DELAY`, `scalerValue: 4` | `scaling: {type: "QUEUE_DELAY", queueDelay: 4}` |
+| idle scale-down | `idleTimeout: 5` | `workers: {…, idleTimeout: 5}` |
+
+`queueDelay` is seconds and accepts fractions (min `0.5`); `requestCount` is an integer
+(min `1`); `idleTimeout` is `1`–`3600` and on a queue-based endpoint scaling on
+`requestCount` it is **rejected on create and update** — not silently ignored.
+
+You only need the right-hand column when calling **v2 REST by hand**. Neither CLI makes you
+write it, but for different reasons, and the distinction matters:
+
+- **runpodctl** never talks to v2 REST at all — `serverless create` goes through GraphQL
+  `saveEndpoint` and `serverless update` through v1 REST, both of which take the flat
+  `scalerType`/`scalerValue`/`idleTimeout` natively. Note `--scale-threshold` is an integer
+  with a floor of 1, so runpodctl **cannot express a fractional `queueDelay`** like `0.5`;
+  use v2 REST or the Console for that.
+- **The Runpod MCP server** keeps the flat `scalerType`/`scalerValue` parameters and maps them
+  onto the nested v2 body for you. A server old enough to predate the reshape sends the flat
+  shape straight through and gets a 422 on both `create-endpoint` and `update-endpoint`; the
+  tell is a `create-endpoint` with no `endpointType` parameter.
 
 ## Walkthrough (verified commands)
 
@@ -119,6 +146,12 @@ runpodctl serverless create --template-id <template-id> --name gp13-reqcount \
 { "id": "<endpoint-id>", "scalerType": "REQUEST_COUNT", "scalerValue": 1,
   "idleTimeout": 5, "workersMax": 3, "flashboot": true }
 ```
+
+> ⚠️ **Don't translate this exact config to v2 REST.** It works here because runpodctl creates
+> through GraphQL, which accepts `REQUEST_COUNT` alongside `idleTimeout` on a queue endpoint.
+> v2 REST **rejects** that pair — `idleTimeout` is "not applicable to queue-based endpoints
+> scaling on `requestCount`". On v2, either scale a queue endpoint on `queueDelay` and keep
+> `idleTimeout`, or scale on `requestCount` and drop it.
 
 ### 3. Fire a burst and WATCH `/health`
 ```bash
@@ -182,7 +215,8 @@ A warm `/runsync` confirms jobs complete cleanly throughout:
 - **runpodctl v2.3 flags changed.** Use `--scale-by requests|delay` + `--scale-threshold N`
   on both `serverless create` and `serverless update`. The old
   `--scaler-type REQUEST_COUNT` / `--scaler-value` flags were removed; passing the enum
-  values won't work. (Stored fields are still `scalerType`/`scalerValue` in REST/GraphQL.)
+  values won't work. (Stored fields are still `scalerType`/`scalerValue` in **v1** REST and
+  GraphQL; v2 REST nests them per scaler — see the mapping table above.)
 - **Reconfigure without redeploying.** `runpodctl serverless update <id> --scale-by …
   --scale-threshold … --workers-max … --idle-timeout …` changes scaling on a live endpoint;
   no new template/endpoint needed.

--- a/plugins/runpod/skills/runpod/golden-paths/14-load-balancing-endpoint.md
+++ b/plugins/runpod/skills/runpod/golden-paths/14-load-balancing-endpoint.md
@@ -9,8 +9,8 @@ API** (no Console, no flash).
 and `GET /ping`, `POST /echo`, `GET /stats` all returned `200` at
 `https://<ENDPOINT_ID>.api.runpod.ai/<path>` with request state persisting on the worker.
 **Lane(s):** custom Docker image + `runpodctl template create` + **GraphQL `saveEndpoint`
-(`type: "LB"`)** + plain HTTP invocation. (flash covers LB code-first; this is the
-image/API way.)
+(`type: "LB"`)** or **v2 REST / Runpod MCP (`LOAD_BALANCER`)** + plain HTTP invocation.
+(flash covers LB code-first; this is the image/API way.)
 
 ## When to use this
 Reach for a load-balancing endpoint instead of the queue/handler model when you need:
@@ -57,9 +57,10 @@ enforces bearer auth (`Authorization: Bearer <RUNPOD_API_KEY>`) at the edge befo
 ## Prerequisites
 - `RUNPOD_API_KEY` exported; Docker running; a Docker Hub (or other) registry login.
 - `runpodctl` (any recent version — used only for `template create`).
-- The **endpoint type is set via GraphQL `saveEndpoint`** (`type: "LB"`). As of this writing
-  neither the REST `POST /v1/endpoints` body nor `runpodctl serverless create` exposes an
-  endpoint-type field, so the LB flag is only reachable via GraphQL (or the Console).
+- The endpoint type is set by **v2 REST** (`"type": "LOAD_BALANCER"` on `POST /v2/serverless`)
+  or by **GraphQL `saveEndpoint`** (`type: "LB"`). Neither the **v1** REST
+  `POST /v1/endpoints` body nor `runpodctl serverless create` exposes an endpoint-type field,
+  so those two can't produce a load balancer.
 
 ## Walkthrough (verified commands)
 
@@ -123,10 +124,45 @@ runpodctl template create --name gp14-lb-tmpl2 --serverless \
 # → template id, e.g. <template-id>
 ```
 
-### 3. Create the endpoint as `type: "LB"` (GraphQL)
-The only headless switch for the load-balancing type is the GraphQL `saveEndpoint` `type`
-field (`QB` = queue-based default, `LB` = load balancing). Use a browser `User-Agent`
-(Cloudflare) and pass the api key in the query string:
+### 3. Create the endpoint as a load balancer
+
+Two headless routes. Prefer **a** — v2 REST is the current shape on both the production
+and dev hosts (verified 2026-07-29: both serve a byte-identical OpenAPI spec).
+
+**a. v2 REST / Runpod MCP (preferred).** v2 REST takes `"type": "LOAD_BALANCER"` on
+`POST /v2/serverless`. Load balancers have no queue, so the scaler must be
+`REQUEST_COUNT` — the spec forbids `QUEUE_DELAY` for this type **on create**. Read the
+invoke URL from the reply's `requestUrls.base` rather than assembling it:
+
+```bash
+curl -s -X POST https://v2-rest.runpod.io/v2/serverless \
+  -H "Authorization: Bearer $RUNPOD_API_KEY" -H 'Content-Type: application/json' \
+  -d '{"name":"gp14-lb-ep","image":"<your-registry>/gp14-lb:v1","type":"LOAD_BALANCER",
+       "gpu":{"pools":["ADA_24"],"count":1},"disk":5,"ports":["5000/http"],
+       "env":{"PORT":"5000","PORT_HEALTH":"5000"},
+       "workers":{"min":0,"max":1,"idleTimeout":5},
+       "scaling":{"type":"REQUEST_COUNT","requestCount":4}}'
+# → {"id":"<endpoint-id>","type":"LOAD_BALANCER",
+#    "requestUrls":{"base":"https://<endpoint-id>.api.runpod.ai",
+#                   "health":"https://<endpoint-id>.api.runpod.ai/ping"}, ...}
+```
+
+This is image-based (no template needed), so step 2 is optional on this route. `type` is
+**required** on create (the spec lists it alongside `name`/`image`/`gpu`/`scaling`) and
+**fixed** afterwards — `UpdateEndpointRequest` has no `type` field, so no PATCH can change
+it.
+
+> **Via the Runpod MCP server:** `create-endpoint` takes `endpointType: "LOAD_BALANCER"` and
+> rejects `scalerType: QUEUE_DELAY` for it client-side, before spending a round trip — the
+> shortest path when MCP is connected.
+>
+> If your server's `create-endpoint` has **no `endpointType` parameter**, it predates the v2
+> serverless reshape and will 422 against production on any endpoint create or update. Upgrade
+> it, or use the raw v2 REST call above meanwhile.
+
+**b. GraphQL `saveEndpoint`.** The `type` field takes `QB`
+(queue-based, the default) or `LB`. Use a browser `User-Agent` (Cloudflare) and pass the
+api key in the query string:
 
 ```bash
 curl -s -X POST "https://api.runpod.io/graphql?api_key=$RUNPOD_API_KEY" \
@@ -140,6 +176,11 @@ curl -s -X POST "https://api.runpod.io/graphql?api_key=$RUNPOD_API_KEY" \
 `gpuIds` is required by `saveEndpoint` (tiers: `AMPERE_16`/`AMPERE_24`/`ADA_24`/`AMPERE_48`/
 `ADA_48_PRO`/`AMPERE_80`/`ADA_80_PRO`). `workersMin: 0` = scale-to-zero. Confirm the type
 stuck: the mutation echoes `"type": "LB"`.
+
+GraphQL still accepts `scalerType: "QUEUE_DELAY"` on an `LB` endpoint (it is the legacy
+flat scaler field and is not validated against the type here). It is not meaningful — a
+load balancer has no queue to measure — and the v2 REST route above rejects the same
+combination, so prefer `scalerType: "REQUEST_COUNT"` even on this route.
 
 > **See also:** [17 — WebSocket worker](17-serverless-websocket.md) applies this same
 > `type: "LB"` substrate to a WebSocket server — start here to understand the LB base path,
@@ -182,11 +223,13 @@ you're talking to the worker's own long-lived process directly, not a stateless 
   The fix that worked here: expose the exact port on the template (`--ports "5000/http"`)
   **and** set **both** `PORT` and `PORT_HEALTH` env vars to it. Relying on the documented
   `PORT` default of `80` alone was not sufficient in practice — set them explicitly.
-- **`type: "LB"` is GraphQL-only (headless).** REST `EndpointCreateInput` and
-  `runpodctl serverless create` have no endpoint-type field, so you can't flip an endpoint to
-  load-balancing through them — use `saveEndpoint` (or the Console's **Endpoint Type →
-  Load Balancer**). A queue-based worker image called on an LB path — or vice versa —
-  returns `{"error":"not allowed for QB API"}`.
+- **The type is set at creation, by v2 REST or GraphQL only.** v2 REST takes
+  `"type": "LOAD_BALANCER"`; GraphQL `saveEndpoint` takes `type: "LB"`. **v1** REST
+  `EndpointCreateInput` and `runpodctl serverless create` have no endpoint-type field. There is
+  no way to *flip* an existing endpoint either way — `UpdateEndpointRequest` has no `type`
+  field at all, so create it right or recreate it (or use the Console's **Endpoint Type →
+  Load Balancer** at creation). A queue-based worker image called on an LB path — or vice
+  versa — returns `{"error":"not allowed for QB API"}`.
 - **Two URLs, don't mix them.** LB is invoked at `https://<ID>.api.runpod.ai/<path>`; the
   queue API lives at `https://api.runpod.ai/v2/<ID>/run`. The `/health` worker-count endpoint
   (`.../v2/<ID>/health`) still works for LB endpoints and is the cleanest readiness signal.
@@ -219,9 +262,11 @@ runpodctl serverless list          # confirm the endpoint is gone
 Kept image: `<your-registry>/gp14-lb:v1` (the tiny stdlib LB worker above).
 
 ## Skill gaps folded back
-- The load-balancing endpoint **type is only settable headlessly via GraphQL `saveEndpoint`
-  `type: "LB"`** — REST endpoint-create and `runpodctl serverless create` have no type field.
-  Skills that create endpoints should note this when a custom-HTTP/LB endpoint is wanted.
+- The load-balancing endpoint type is settable headlessly two ways: **v2 REST**
+  (`"type": "LOAD_BALANCER"`) or **GraphQL `saveEndpoint`** (`type: "LB"`). **v1** REST
+  endpoint-create and `runpodctl serverless create` have no type field, and no API can change
+  the type after creation. Skills that create endpoints should note this when a custom-HTTP/LB
+  endpoint is wanted.
 - **Setting `PORT_HEALTH` (and exposing the port) explicitly is effectively required**, not
   optional — a worker that binds the app port but leaves `PORT_HEALTH` at its documented
   default failed to become `ready`. Treat "expose the port + set `PORT` + set `PORT_HEALTH`"


### PR DESCRIPTION
Docs counterpart to **runpod/runpod-mcp#58**. Two claims in the plugin are now wrong.

### Golden path 14 — "GraphQL is the only headless way to make an LB endpoint"

No longer true. v2 REST takes `"type": "LOAD_BALANCER"`, and MCP `create-endpoint` takes `endpointType: "LOAD_BALANCER"`.

Step 3 now has two labelled routes instead of one:

- **a. v2 REST / MCP** — image-based, no template step. Points at `requestUrls.base` rather than hand-assembling the invoke URL. Carries a host-dependency warning, because an older prod host rejects that body **and has no `type` field at all** — so a `type`-less create there silently yields a *queue* endpoint.
- **b. GraphQL `saveEndpoint`** — kept as-is; works on every host today.

Also flags that GraphQL accepts a meaningless `scalerType: QUEUE_DELAY` on an LB endpoint while v2 REST rejects it. The existing recipe in that file had exactly that combination.

### Golden path 13 — "the fields are named `scalerType`/`scalerValue` in REST/GraphQL"

True for **v1** and GraphQL only. v2 nests them per scaler and moved `idleTimeout` under `workers`. Added the v1→v2 mapping table and the value bounds.

### Also

`runpod-mcp/SKILL.md` — the Serverless bullet documents `endpointType` and points at `requestUrls`.

---

<details>
<summary>Test plan</summary>

Docs only; no skill logic touched. All four validators pass:

```
validate_marketplace.py    → OK
check_versions.py          → OK (all manifests + skills at 1.1.0)
check_runpod_branding.py   → OK
check_links.py             → OK
```

Every API claim was verified live against both hosts while building #58 — including the `LOAD_BALANCER` create returning `requestUrls.base` + `health`, and both business-rule rejections quoted in golden path 14.

</details>

---

- Code counterpart: runpod/runpod-mcp#58
- **No overlap with #39** — that PR touches the Tags/Container-registry bullets and `runpod-usage/reference/gotchas.md`; this one touches the Serverless bullet and golden paths 13/14.
- Linear: [CON-817](https://linear.app/runpod/issue/CON-817/runpod-mcp-official-plugin-v2-v2serverless-write-schema-break-endpoint)
