### PR TITLE
docs(runpodctl): document coded json errors, invoke urls, gpu pricing

### DIFF
--- a/plugins/runpod/skills/runpod-usage/reference/gpu-selection.md
+++ b/plugins/runpod/skills/runpod-usage/reference/gpu-selection.md
@@ -76,10 +76,15 @@ usually beats two 40 GB cards for a model that fits.
 
 ## Step 5: availability and multi-GPU selection
 
-Note: the CLI (`runpodctl gpu list`) does **not** report `$/hr`, so an agent can't
-read "cheapest" from it — pick the **smallest tier that fits** the workload (lower
-tiers are generally cheaper) and check per-region stock with `runpodctl datacenter
-list` before creating. Prices are on the Runpod pricing page / Console.
+`runpodctl gpu list` reports on-demand `securePricePerHr` / `communityPricePerHr` per
+GPU (explicitly `null` when that cloud doesn't offer it) plus a
+`dataCenterAvailability[]` breakdown, so read cost and per-region stock straight from
+it rather than assuming a lower tier is cheaper. Top-level `stockStatus` is only the
+best status across DCs — use the per-DC breakdown when placement matters (`runpodctl
+datacenter list` gives the same view from the DC side). Two scope limits: those are **pod
+on-demand** rates (serverless bills per request-second), and the per-DC breakdown doesn't
+say *which cloud* has the stock, so cost and placement are two separate reads rather than
+one ranked list.
 
 GPU supply fluctuates by tier and region. To avoid throttling:
 

--- a/plugins/runpod/skills/runpodctl/SKILL.md
+++ b/plugins/runpod/skills/runpodctl/SKILL.md
@@ -68,6 +68,53 @@ runpodctl <resource> <action> --help
 
 Before using unfamiliar commands, inspect live help first. Do not rely on this skill as an exhaustive flag reference.
 
+**What live help does *not* cover:** output shapes, error codes, and exit-code behavior. `--help` lists flags; it never shows you what a failure looks like. For those, use [reference/output-and-errors.md](reference/output-and-errors.md) — and when in doubt, **probe the binary**: run the command wrong on purpose (`runpodctl serverless get nope`) and read the JSON it emits. Every doc is a snapshot, this skill included; the binary in front of you wins.
+
+## Output & errors
+
+Data is **JSON on stdout** (`--output=yaml` is the only alternative — there is no table
+format; anything else silently returns JSON). A failure from the resource commands is a
+single flat JSON object on **stderr** plus a **non-zero exit**:
+
+```jsonc
+{"error":"failed to get endpoint: endpoint not found","code":"not_found","status":404}
+```
+
+**Branch on `code`, never on `status` or the message.** `status` is there only when the
+failure arrived on a non-2xx response — GraphQL reports a missing resource as HTTP 200 +
+null data, so `if status == 404` misses every GraphQL not-found.
+
+| `code` | what to do |
+| --- | --- |
+| `network_error` | **retry with backoff** — the only code meaning "couldn't reach the API" |
+| `rate_limited` `server_error` | **retry with backoff** — 429/5xx from the API |
+| `usage_error` `cli_error` `bad_request` `not_found` `conflict` | don't retry, fix the input |
+| `no_credentials` | no key set: `export RUNPOD_API_KEY=…` or `runpodctl doctor` |
+| `unauthorized` `forbidden` | a key **is** set but is wrong/expired or lacks access — don't retry, don't re-prompt for a missing key |
+| anything else | treat as fatal, surface `error` verbatim — the API can pass through its own code |
+
+**runpodctl never retries internally**; nothing backs off for you.
+
+- **`not_found` always means the API lacks the resource**, never a mistyped local path
+  (that's `cli_error`).
+- **`cli_error` is a mixed bucket:** local environment problems *and* invocation mistakes
+  the command validates itself (e.g. `ssh remove-key` with neither `--name` nor
+  `--fingerprint`). Only cobra-enforced required flags are `usage_error`.
+- **`usage_error`** = unknown command/flag, bad args, missing cobra-required flag; usage
+  text follows the JSON. Runtime errors no longer print usage.
+- **Non-empty stderr does not mean failure** — deprecation `warning:` and `note:` lines go
+  to stderr on success too. Gate on the exit code, then parse stderr.
+
+Coded errors, the serverless `urls` object and GPU pricing all need **runpodctl ≥ v2.8.0**.
+Older binaries emit `{"error":"…"}` with **no `code` and no `status`** — still JSON-shaped,
+so a `switch (err.code)` silently gets `undefined` rather than failing loudly. **Gate on
+`code` being present**, not on JSON-vs-plaintext; `runpodctl version` is unreliable for
+this (plaintext, and a source build reports a placeholder version).
+
+Full code table, the surfaces that still print plaintext (`exec`, legacy `pod`
+commands, `project`), and the env-var table (incl. `RUNPOD_INVOKE_URL`):
+**[reference/output-and-errors.md](reference/output-and-errors.md)**.
+
 ## Decision Rules
 
 - Use Hub when the user wants a known deployable app or worker such as vLLM, ComfyUI, Whisper, or a Runpod-maintained repo.
@@ -128,6 +175,12 @@ runpodctl serverless create --hub-id <id> --gpu-id "NVIDIA GeForce RTX 4090" \
   --model-reference https://huggingface.co/<org>/<model>:main   # attach & host-cache a HF model (GPU only)
 runpodctl serverless update <endpoint-id> --workers-max 5
 ```
+
+**Invoke URLs come back with the endpoint.** `create`/`get`/`list`/`update` include a
+`urls` object (`run`, `runsync`, `health`), so a freshly created endpoint is callable
+without a second lookup — read them instead of assembling the URL yourself. They're
+built from `RUNPOD_INVOKE_URL` (default `https://api.runpod.ai/v2`), which
+`RUNPOD_API_URL`/`RUNPOD_GRAPHQL_URL` do **not** move: [reference/output-and-errors.md](reference/output-and-errors.md#serverless-invoke-urls).
 
 **Create from hub:** `--hub-id` resolves the hub listing, extracts the build image and config (GPU IDs, container disk, env vars), creates an inline template, and deploys. Accepts both SERVERLESS and POD listing types. GPU IDs and env var defaults from the hub config are included automatically; override with `--gpu-id` and `--env`.
 
@@ -195,10 +248,20 @@ runpodctl model remove --name "my-model" --owner <owner>     # Remove a model
 
 ```bash
 runpodctl user                                       # account info + balance (alias: me)
-runpodctl gpu list                                   # available GPUs (+ --include-unavailable)
+runpodctl gpu list                                   # available GPUs + $/hr + per-DC stock (+ --include-unavailable)
 runpodctl datacenter list                            # datacenters (alias: dc)
 runpodctl ssh info <pod-id>                          # SSH connection details (command + key; NOT an interactive session)
 ```
+
+**`gpu list` carries pricing and placement data** — `securePricePerHr` /
+`communityPricePerHr` (explicitly `null` when that cloud doesn't offer the GPU) and a
+`dataCenterAvailability[]` breakdown. Read the breakdown, not just top-level
+`stockStatus` (which is only the *best* status across DCs), when a create has to
+schedule in a specific DC — and pass `--include-unavailable`, since the default listing
+hides no-stock GPUs and can omit one that has stock only in the DC you want. The prices
+are **pod on-demand** rates. Shape, stock-value vocabulary and the `"none"` vs
+omitted-key sentinel:
+[reference/output-and-errors.md](reference/output-and-errors.md#gpu-pricing-and-per-data-center-availability).
 
 `ssh info` gives connection details, not a session — if interactive SSH isn't available, run `ssh user@host "command"`. **Registry auth, `billing` history, and SSH key management** (`ssh add-key`/`remove-key`) are in [reference/command-reference.md](reference/command-reference.md).
 
@@ -240,6 +303,10 @@ https://api.runpod.ai/v2/<endpoint-id>/runsync    # Sync request
 https://api.runpod.ai/v2/<endpoint-id>/health     # Health check
 https://api.runpod.ai/v2/<endpoint-id>/status/<job-id>  # Job status
 ```
+
+`serverless create`/`get`/`list`/`update` already return `run`/`runsync`/`health` in a
+`urls` object — prefer those over hand-assembling, since a non-default
+`RUNPOD_INVOKE_URL` changes the base. Only `status/<job-id>` has to be built by hand.
 
 ## Source & docs
 

--- a/plugins/runpod/skills/runpodctl/evals/error-handling.eval.md
+++ b/plugins/runpod/skills/runpodctl/evals/error-handling.eval.md
@@ -1,0 +1,43 @@
+# Handle a runpodctl failure without parsing message text
+
+## Prompt
+
+I'm scripting `runpodctl` in a loop. Write the failure handling: how do I tell a
+missing endpoint from a bad API key from a blip I should retry? Here are two failures
+I've seen:
+
+```
+{"error":"failed to get endpoint: endpoint not found","code":"not_found","status":404}
+{"error":"failed to get template: template not found: tpl-abc","code":"not_found"}
+```
+
+## Expected behavior
+
+The agent should:
+
+1. Branch on `code`, not on `status` and not on substrings of `error`
+2. Explain that the second failure has no `status` because GraphQL answers a missing
+   resource with HTTP 200 + null data, so `status === 404` misses it
+3. Retry `network_error`, `rate_limited` and `server_error` with backoff, and say why
+   `cli_error` (e.g. malformed `RUNPOD_API_URL`, a timed-out local wait loop) must not be
+4. Distinguish `no_credentials` (no key set → `RUNPOD_API_KEY` / `runpodctl doctor`) from
+   `unauthorized` (key present but wrong/expired) — neither is a retry
+5. Treat `not_found` as server-side, not as a mistyped local path
+6. Gate on a non-zero exit code and read errors from **stderr**, data from stdout — and
+   not treat a `warning:`/`note:` line on stderr as a failure
+7. Include a default branch for an unrecognized `code`, because the vocabulary is what the
+   CLI generates rather than exhaustive (the API can pass its own code through lowercased)
+
+## Assertions
+
+- Switches/branches on `code`
+- Does NOT branch on `status` alone or on `error` text matching
+- Retry set includes `network_error` and at least one of `rate_limited`/`server_error`
+- The produced handler has a default/else branch treating an unknown `code` as fatal
+- Does NOT retry `cli_error`, `usage_error`, `not_found`, `no_credentials`, or
+  `unauthorized`
+- Separates `no_credentials` from `unauthorized` in the auth handling
+- Reads errors from stderr and does NOT expect error JSON on stdout
+- Does NOT claim `status` is always present
+- Does NOT tell the user to parse plaintext for `pod`/`serverless`/`template`/`model`
+  commands (only the legacy `pod` paths, `exec` and `project` still print plaintext)

--- a/plugins/runpod/skills/runpodctl/evals/invoke-urls-and-gpu-pricing.eval.md
+++ b/plugins/runpod/skills/runpodctl/evals/invoke-urls-and-gpu-pricing.eval.md
@@ -1,0 +1,39 @@
+# Read invoke URLs and GPU cost from command output
+
+## Prompt
+
+I'm on a shell-only box with `runpodctl` and no MCP tools. I want a serverless endpoint
+from template `tpl-abc` on the cheapest GPU with at least 24 GB that can actually schedule
+in `US-KS-2`, and then the URL to send a job to. Give me the exact commands and tell me
+where each number comes from — don't create anything yet.
+
+## Expected behavior
+
+The agent should:
+
+1. Run `runpodctl gpu list --include-unavailable` and filter on `memoryInGb >= 24`,
+   noting that the default listing hides no-stock GPUs and could omit one that has stock
+   only in `US-KS-2`
+2. Compare `securePricePerHr` / `communityPricePerHr` rather than assuming a lower tier is
+   cheaper, and treat a `null` price as "not offered on that cloud", not as free
+3. Check `dataCenterAvailability[]` for a `US-KS-2` entry with real stock instead of
+   trusting top-level `stockStatus` (the best status across all DCs), reading `"none"` as
+   "offered here, no stock"
+4. Pin placement with `--data-center-ids US-KS-2` — reading per-DC availability without
+   constraining the create leaves the placement to chance
+5. Say that `--gpu-id` on serverless resolves to a GPU **pool**, so the endpoint may run on
+   more than the single card that was priced, and/or that the listed prices are pod
+   on-demand rates while serverless bills per request-second
+6. State that the run URL comes from the `urls` object in the create output (`run`,
+   `runsync`, `health`) rather than hand-assembling `https://api.runpod.ai/v2/<id>/run`
+
+## Assertions
+
+- Runs `runpodctl gpu list` before choosing a GPU
+- Cites `securePricePerHr` / `communityPricePerHr` for the cost comparison
+- Consults `dataCenterAvailability[]` for `US-KS-2`
+- Command includes `--data-center-ids US-KS-2`
+- Says the run URL will be read from the `urls` object rather than assembled by hand
+- Flags at least one of: the type→pool translation, or that the prices are pod rates
+- Does NOT claim the CLI can't report GPU pricing
+- Does NOT present `securePricePerHr` as the endpoint's serverless cost

--- a/plugins/runpod/skills/runpodctl/reference/command-reference.md
+++ b/plugins/runpod/skills/runpodctl/reference/command-reference.md
@@ -3,6 +3,9 @@
 Live `runpodctl <resource> <action> --help` is always authoritative for exact flags. This
 is the fuller menu (the SKILL keeps the 80% essentials); use it for the long-tail flags.
 
+Output shapes, error codes and env vars are in
+[output-and-errors.md](output-and-errors.md).
+
 ## Pods
 
 ```bash
@@ -110,7 +113,7 @@ runpodctl registry delete <registry-id>               # Delete registry auth
 
 ```bash
 runpodctl user                                        # Account info and balance (alias: me)
-runpodctl gpu list                                    # List available GPUs
+runpodctl gpu list                                    # List available GPUs (+ $/hr per cloud + dataCenterAvailability[])
 runpodctl gpu list --include-unavailable              # Include unavailable GPUs
 runpodctl datacenter list                             # List datacenters (alias: dc)
 runpodctl billing pods                                # Pod billing history

--- a/plugins/runpod/skills/runpodctl/reference/output-and-errors.md
+++ b/plugins/runpod/skills/runpodctl/reference/output-and-errors.md
@@ -1,0 +1,279 @@
+# runpodctl — output format, error codes, env vars
+
+Everything an agent needs to parse runpodctl's output and decide what to do with a
+failure. The 80% rule is in [SKILL.md](../SKILL.md#output--errors); this file is the
+full surface.
+
+**Version floor: runpodctl ≥ v2.8.0.** The coded error shape, the serverless `urls` object
+and GPU pricing/per-DC availability all arrived in v2.8.0.
+
+Older binaries (≤ v2.7.3) did **not** print plaintext — they printed
+`{"error":"<message>"}` on stderr with no `code` and no `status`, and the message was
+interpolated unescaped, so a message containing a quote produced malformed JSON. They also
+dumped usage text after runtime errors. So the pre-v2.8.0 failure mode is *valid-looking
+JSON with the field you're branching on missing* — **gate on `code` being present**, not on
+whether stderr parses as JSON. `runpodctl version` is a weak gate: it prints plaintext, and
+a binary built from source reports a placeholder version regardless of the code it contains.
+
+## Output format
+
+JSON is the **default** — the CLI is built for agent consumption, and data goes to
+**stdout**.
+
+```bash
+runpodctl pod list                    # json (default)
+runpodctl pod list --output=yaml      # yaml — the only alternative
+```
+
+**There is no table format** — `json` and `yaml` are the only values, matched
+**case-sensitively**. An unrecognized value is not an error; it silently falls back to
+JSON, so `--output=table` *and* `--output=YAML` both return JSON. Pass lowercase `yaml` or
+don't pass the flag.
+
+(The legacy `get pod` / `get cloud` commands print a human table on stdout and ignore
+`--output` entirely — see [plaintext gaps](#plaintext-gaps).) Some commands print a human table on stdout regardless — the legacy
+`get pod`/`get cloud` paths do — so a table on stdout is a signal you're on a legacy
+command, not a format you asked for.
+
+## Error format
+
+Errors go to **stderr** as a single flat JSON object, and the exit code is
+**non-zero**, so stdout parses as data.
+
+```jsonc
+{"error":"failed to get endpoint: endpoint not found","code":"not_found","status":404}
+```
+
+| field | notes |
+| --- | --- |
+| `error` | human-readable message, unwrapped on the REST path. A GraphQL HTTP failure whose body has no extractable message falls back to the **raw body**, which can itself be JSON — so never parse this field, either way |
+| `code` | stable, lowercase, present on every JSON error (see [plaintext gaps](#plaintext-gaps)) |
+| `status` | HTTP status — only when the failure arrived on a **non-2xx** response (REST *or* GraphQL) |
+
+**Branch on `code`, never on `status` or the message text.** `status` is absent whenever
+the API answered HTTP 200 with empty data, which is how GraphQL reports a missing
+resource — so `if (status === 404)` misses every GraphQL not-found:
+
+```jsonc
+// serverless get <missing> — REST, so a status is available
+{"error":"failed to get endpoint: endpoint not found","code":"not_found","status":404}
+// template get <missing> — GraphQL answered 200/null, so there is no wire status
+{"error":"failed to get template: template not found: bogus-template-id","code":"not_found"}
+```
+
+`code` is both: a typed code (from the API or from the error itself) wins, and the
+output sink fills in a fallback when there isn't one — so local validation and transport
+failures carry a code too, not just API responses.
+
+### Codes
+
+| code | meaning |
+| --- | --- |
+| `usage_error` | unknown command, unknown flag, bad/wrong-count args, or a **cobra-required** flag left out. Usage text prints after the JSON |
+| `not_found` | the **API** does not have the resource |
+| `bad_request` (400) `unauthorized` (401) `forbidden` (403) `conflict` (409) `rate_limited` (429) `server_error` (5xx) `api_error` | derived from the REST status |
+| `graphql_error` | a GraphQL call failed: an `errors` array in a 200 body, **or** a non-2xx response from the GraphQL endpoint (that form also carries `status`) |
+| `no_credentials` | no API key configured at all — set `RUNPOD_API_KEY` or run `runpodctl doctor` |
+| `network_error` | the API could not be reached at all — DNS, connection refused, TLS, timeout |
+| `cli_error` | anything else local: config, environment, and validation the command does itself |
+
+Treat this as **the set the CLI generates, not an exhaustive list** — an explicit code
+from the API is passed through lowercased, so a code outside the table can arrive from
+the server. **Give your handler a default branch that treats an unknown code as fatal**
+and surfaces `error` verbatim; never fall through to a retry.
+
+### What to retry
+
+**runpodctl has no internal retry** — it never backs off for you, so whatever your
+wrapper does is all that happens.
+
+- **Retry with backoff:** `network_error`, `rate_limited`, `server_error` (and `api_error`
+  when `status` is 5xx). A transient `graphql_error` is possible too but indistinguishable
+  from a permanent one, so cap those attempts tightly.
+- **Never retry:** `usage_error`, `cli_error`, `bad_request`, `not_found`, `conflict`,
+  `no_credentials`, `unauthorized`, `forbidden`.
+
+Two invariants make that safe to encode:
+
+- **`not_found` always means server-side.** A bad *local* path (say a mistyped
+  `--model-path`) is `cli_error`, so `not_found` never means "you typed a path wrong".
+- **`network_error` is the only code the CLI assigns to mean "couldn't reach the API"**,
+  detected structurally. Deliberately *not* `network_error`: a malformed `RUNPOD_API_URL`
+  and a local wait loop timing out (e.g. `--wait-for-hash`) are both `cli_error`, so a
+  retry loop never fires for something a retry cannot fix.
+
+### Auth failures are two different codes
+
+`no_credentials` means **no key is configured**. A key that is present but wrong, expired
+or revoked is `unauthorized` (401), and one lacking access to the resource is `forbidden`
+(403):
+
+```jsonc
+// RUNPOD_API_KEY=rpa_bogus… pod list
+{"error":"api request failed with status 401","code":"unauthorized","status":401}
+```
+
+Don't collapse these — re-prompting for a "missing" key when the real problem is a
+revoked one sends an agent in a circle.
+
+### Invocation mistakes split across two codes
+
+`usage_error` covers what cobra validates: unknown command/flag, wrong arg count, and
+missing `MarkFlagRequired` flags. Validation a command performs itself lands in
+`cli_error`, even though it's just as much an invocation mistake:
+
+```jsonc
+// ssh remove-key with neither --name nor --fingerprint
+{"error":"either --fingerprint or --name must be provided","code":"cli_error"}
+```
+
+So `cli_error` is a mixed bucket — "your invocation was wrong" *and* "your local
+environment is wrong". Read `error` to tell them apart; don't retry either.
+
+### Missing API key
+
+The JSON-covered commands all report `no_credentials` — `pod` (`list`/`get`/`create`),
+`template create`/`update`, every `ssh` subcommand, `model *`:
+
+```jsonc
+{"error":"api key not found. get your key at https://www.runpod.io/console/user/settings then: export RUNPOD_API_KEY=your-key OR run: runpodctl doctor","code":"no_credentials"}
+```
+
+```jsonc
+{"error":"unknown flag: --nope","code":"usage_error"}
+```
+
+Usage text follows the JSON on stderr — and, unlike older builds, a *runtime* error no
+longer dumps usage text after it.
+
+### Exit codes, and what else is on stderr
+
+Every failure on the JSON path exits non-zero (`model` and `update` used to print an error
+and exit **0**; they don't anymore). The exceptions are in
+[plaintext gaps](#plaintext-gaps) below.
+
+**Non-empty stderr is not a failure signal.** Deprecation notices (`warning: 'runpodctl
+get pod' is deprecated…`), `pod create` advisories (`note: …`) and config-migration lines
+all go to stderr on successful runs. Gate on the exit code first, then parse stderr.
+
+### Plaintext gaps
+
+The JSON error shape covers `pod`, `serverless`, `template`, `volume`, `registry`,
+`gpu`, `datacenter`, `billing`, `user`, `model`, `ssh`, `send`, `receive`, `hub` and
+`update` — including every GraphQL call site (a GraphQL failure is `graphql_error`, or
+`not_found` for the nil-data lookups). These surfaces still print plaintext and carry
+no `code`:
+
+| surface | shape |
+| --- | --- |
+| legacy `get`/`create`/`remove`/`start`/`stop pod`, `create`/`remove pods`, `get cloud` | `Error: <msg>` on stderr, exit 1 — including the missing-key case, which carries the same message as `no_credentials` but no JSON and no `code`. Success prints a human **table** on stdout, not JSON |
+| `exec` (hidden, deprecated) | progress on **stdout**, error plaintext on stderr, **exit 0**; polls up to **5 minutes** for the pod's SSH info before giving up |
+| `project` (hidden) | prints errors to **stdout** and exits **0** |
+
+### Parsing `ssh info`
+
+`ssh info` has three shapes, and only one of them is an error:
+
+| situation | output |
+| --- | --- |
+| connectable | `{"id","name","ssh_command","ip","port","ssh_key":{…}}` on stdout, exit 0 — note **snake_case**, unlike the camelCase everywhere else in the CLI. A `"setup":"runpodctl doctor"` key appears when the local key needs fixing |
+| pod exists, not connectable | `{"error":"pod not ready","id":…,"name":…,"status":…}` on **stdout**, exit **0**, no `code`. Here `status` is the pod's desired status, *not* an HTTP status |
+| no such pod | `{"error":"pod 'x' not found","code":"not_found"}` on stderr, exit 1 |
+
+So: check the exit code, then check for an `error` key even on stdout.
+
+"Not ready" fires whenever the pod has no **public port 22**, which is not the same thing
+as "still booting". A pod whose image never starts an sshd reports
+`{"error":"pod not ready","status":"RUNNING"}` indefinitely — verified by creating a
+`ubuntu:22.04` CPU pod and polling for ~70 s at `status: RUNNING` throughout. So **bound
+any SSH readiness loop** and don't treat `RUNNING` as "SSH is coming"; if it never arrives,
+the image is the problem, not the wait.
+
+So a parser should tolerate a non-JSON line on stderr from those, and must not rely on
+the exit code for `exec` or `project`. Prefer the non-legacy equivalents: `pod
+get`/`pod create`/`pod delete`, and `ssh info <pod-id>` + your own `ssh` invocation
+instead of `exec`.
+
+## Environment variables
+
+| variable | default | what it sets |
+| --- | --- | --- |
+| `RUNPOD_API_KEY` | — | API key. Also settable via `runpodctl doctor` or `~/.runpod/config.toml` (`apikey`) |
+| `RUNPOD_API_URL` | `https://rest.runpod.io/v1` | REST control plane (config key `restApiUrl`) |
+| `RUNPOD_GRAPHQL_URL` | `https://api.runpod.io/graphql` | GraphQL control plane (config key `apiUrl`) |
+| `RUNPOD_INVOKE_URL` | `https://api.runpod.ai/v2` | base for the invoke URLs reported by `serverless create`/`get`/`list`/`update` (config key `invokeUrl`) |
+
+**Invoke is a separate service from the control plane.** Pointing `RUNPOD_API_URL` or
+`RUNPOD_GRAPHQL_URL` at a non-prod host does *not* move the invoke URLs — override
+`RUNPOD_INVOKE_URL` explicitly when you need that, or the emitted URLs target prod.
+
+## Serverless invoke URLs
+
+`serverless create`/`get`/`list`/`update` return a `urls` object, computed from the
+endpoint ID, so a freshly created endpoint is callable without a second lookup:
+
+```jsonc
+"urls": {
+  "run":     "https://api.runpod.ai/v2/<endpoint-id>/run",
+  "runsync": "https://api.runpod.ai/v2/<endpoint-id>/runsync",
+  "health":  "https://api.runpod.ai/v2/<endpoint-id>/health"
+}
+```
+
+`status` isn't in the object; it's `<run url minus /run>/status/<job-id>`.
+
+## GPU pricing and per-data-center availability
+
+`gpu list` reports on-demand price per hour per cloud type plus a per-DC stock
+breakdown:
+
+```jsonc
+{
+  "gpuId": "NVIDIA A100 80GB PCIe",
+  "displayName": "A100 PCIe",
+  "memoryInGb": 80,
+  "secureCloud": true,          "securePricePerHr": 1.39,
+  "communityCloud": true,       "communityPricePerHr": 1.19,
+  "stockStatus": "Low",         "available": true,
+  "dataCenterAvailability": [
+    {"dataCenterId": "CA-MTL-3", "stockStatus": "Low"},
+    {"dataCenterId": "EU-RO-1",  "stockStatus": "none"}
+  ]
+}
+```
+
+- A price is **explicitly `null`** when that cloud type doesn't offer the GPU, which is
+  distinguishable from a real `0`. Read `securePricePerHr`/`communityPricePerHr` rather
+  than guessing that a lower tier is cheaper.
+- Top-level `stockStatus` is the **best status across data centers** — use
+  `dataCenterAvailability[]` as ground truth for *where* a create will actually
+  schedule, especially when co-locating with a network volume.
+- An unrecognized non-empty status now ranks above absent/`none` instead of tying with it,
+  so **`available` no longer reports `false`** for a GPU whose only status is a value the
+  CLI doesn't know. It still ranks *below* `Low`, so a known level still wins the top-level
+  `stockStatus` — that tradeoff is deliberate, and it's why `dataCenterAvailability[]` is
+  the field to read. Casing and surrounding whitespace are normalized now, so they are no
+  longer a source of unknown values.
+- Two sentinels for one concept: the per-DC breakdown spells an unreported status
+  `"none"`, while the top-level field **omits the key** for the same condition. Handle
+  both.
+- **Stock values are capitalized levels but the sentinel is lowercase** — `"High"`,
+  `"Medium"`, `"Low"`, `"none"` in practice. `"unavailable"`, `"out of stock"` and
+  `"no stock"` also count as no-stock, and comparison is case-insensitive internally, so
+  lowercase before testing and don't write `if s != "none"`.
+- **`gpu list` hides no-stock GPUs by default.** Pass `--include-unavailable` when
+  targeting one data center, or you may never see a GPU that has stock only there.
+
+Two scoping limits the fields don't express:
+
+- **The prices are pod on-demand rates** (`gpuTypes { securePrice communityPrice }`). They
+  are not serverless rates — serverless bills per request-second — so don't present them
+  as the cost of an endpoint.
+- **`dataCenterAvailability[]` has no cloud-type attribution**, while pricing is split
+  secure vs community. "Cheapest option that schedules in DC X" therefore isn't answerable
+  from `gpu list` alone; treat it as two separate reads.
+
+And when you act on the choice: pin placement with `--data-center-ids`, or the analysis
+doesn't constrain anything. For serverless, `--gpu-id` takes a GPU *type* id and is
+translated server-side to a GPU **pool**, so the endpoint may run on more than the one
+card you priced (pool vs type ids: [`runpod-usage` gpu-selection](../../runpod-usage/reference/gpu-selection.md)).


### PR DESCRIPTION
## What & why

runpodctl **v2.8.0** ([#306](https://github.com/runpod/runpodctl/pull/306) + [#312](https://github.com/runpod/runpodctl/pull/312)) changed its agent-facing output. The skill documented none of it:

- every failure is a flat JSON object on stderr with a stable `code` + non-zero exit
- `serverless create/get/list/update` return a `urls` object (`run`, `runsync`, `health`)
- `gpu list` returns `securePricePerHr` / `communityPricePerHr` + `dataCenterAvailability[]`

Closes CON-752. runpodctl's `AGENTS.md` makes skill sync a repo-policy obligation, so this isn't optional polish.

**Changes**

| File | What |
|---|---|
| `runpodctl/SKILL.md` | new **Output & errors** section — branch on `code` not `status`, `network_error` is the only retryable code, `not_found` is always server-side, `usage_error` includes missing required flags, `≥ v2.8.0` floor. Plus the `urls` object in Serverless and pricing/per-DC on `gpu list` |
| `runpodctl/reference/output-and-errors.md` | new — full 13-code table, field shapes, exit codes, surfaces still printing plaintext, env vars incl. `RUNPOD_INVOKE_URL`, `urls` + gpu shapes |
| `runpod-usage/reference/gpu-selection.md` | dropped the now-false "`gpu list` does **not** report `\$/hr` … prices are on the pricing page" |
| `runpodctl/evals/` ×2 | error-code branching; reading urls + pricing from output |

<details>
<summary>Verified against a v2.8.0 build, not copied from the README</summary>

Built `runpodctl` at `22dc71f` and ran it:

- `serverless get <missing>` → `{"error":"…endpoint not found","code":"not_found","status":404}`
- `template get <missing>` → `{"error":"…template not found: …","code":"not_found"}` — **no `status`** (GraphQL answers 200 + null data), which is why the skill says branch on `code`
- `pod list --nope` → `{"error":"unknown flag: --nope","code":"usage_error"}`
- keyless `pod list` → `code":"no_credentials"`
- `gpu list` → real `securePricePerHr`/`communityPricePerHr` + `dataCenterAvailability[]` with the `"none"` sentinel
- `serverless list` → `urls{run,runsync,health}` (and `serverless update` reprints `GetEndpoint`'s object, so it can't lack them)
- `ssh info` on a throwaway `ubuntu:22.04` CPU pod → `{"error":"pod not ready","status":"RUNNING"}` on **stdout**, exit **0**, held for ~70 s (pod deleted; ~$0.002)

Source-verified but not live: `urls` on `serverless create` (same `invokeURLs` helper as the four verified call sites) and the `ssh info` *connectable* shape.

Version floor: `fallbackCode`, `invokeURLs`, `SecurePricePerHr` and the `cmd/model` coded errors all trace to `22dc71f`; `git tag --contains` → only `v2.8.0`, and it is not an ancestor of `v2.7.3`. Nothing shipped in v2.7.x.

Pre-v2.8.0 behavior was checked too, because it drives the gating advice: `git show v2.7.3:cmd/root.go` emitted ``{"error":"%s"}`` with no `code`/`status` (and unescaped), so the old failure mode is valid-looking JSON missing the field you branch on — the skill tells agents to gate on `code` being present, not on JSON-vs-plaintext.

</details>

<details>
<summary>Two upstream follow-ups found while verifying (not in this PR)</summary>

1. **runpodctl's README `exec` row is wrong.** It says "plaintext, exit 1". `cmd/exec/commands.go:22-25` uses `Run` (not `RunE`) and only `Fprintf`s to stderr → **exit 0**; it also prints progress to stdout and polls up to 5 min (`cmd/project/ssh.go:24`). This skill documents the verified behavior, so it intentionally diverges from its own named source.
2. **runpodctl's `AGENTS.md`** still points skill sync at `github.com/runpod/skills/tree/main/runpodctl` — stale twice over (repo renamed, skill moved under `plugins/runpod/skills/`).
3. **The README documents an `--output=table` that doesn't exist.** `internal/output/output.go`'s `ParseFormat` maps only `yaml` and sends everything else to JSON; `--output=table` on a live binary returns JSON. (This skill originally repeated the claim — caught in review and removed.)

</details>

## Checklist
- [x] Updated the doc(s) this change affects (SKILL.md / reference / golden-path / AGENTS.md), or N/A
- [x] If a rule/behavior changed, kept it consistent across the router + affected skills
- [x] Ran the hooks locally: \`validate_marketplace\` · \`check_versions\` · \`check_runpod_branding\` · \`check_links\`
- [x] Did NOT hand-edit versions or \`CHANGELOG.md\` released sections (release-please owns those)


