### PR TITLE
chore(marketplace): use a catalog-standard category

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "displayName": "Runpod (Official)",
       "description": "Official Runpod skills and MCP server: a router plus lanes (runpodctl, flash, companion CLIs, conceptual usage) that bundles the hosted Runpod MCP server.",
       "source": "./plugins/runpod",
-      "category": "Infrastructure",
+      "category": "deployment",
       "skills": [
         "./skills/runpod",
         "./skills/runpod-mcp",


### PR DESCRIPTION
## What & why

One line in `.claude-plugin/marketplace.json`: `"Infrastructure"` → `"deployment"`.

Cosmetic, pre-submission hygiene. `Infrastructure` appears **zero** times across Anthropic's two catalogs (276 official + 2307 community entries) — they use a lowercase set, and every comparable compute/hosting vendor listed there uses `deployment`.

Not a blocker for anything: the category is a display/filter facet, and `claude plugin validate` passes either way. Splitting it out so it doesn't ride along with unrelated docs work.

<details>
<summary>Category evidence from the live catalogs</summary>

Values in use in `claude-plugins-official` (276 entries):

```
development 116 · productivity 48 · database 36 · monitoring 19 · security 17
deployment 8 · design 7 · learning 3 · location 2 · automation 2 · testing 2
migration 1 · math 1 · (none) 14
```

Peer group — platforms you deploy compute onto:

| plugin | category |
| --- | --- |
| cloudflare | `deployment` |
| vercel | `deployment` |
| railway | `deployment` |
| render | `deployment` |
| deploy-on-aws | `deployment` |

(Vendors whose plugin is an SDK/toolkit rather than a target — `aws-core`, `nvidia-skills`, `netlify-skills`, `togetherai-skills` — use `development`. Runpod is the former.)

</details>

<details>
<summary>Why only the Claude manifest</summary>

`.agents/plugins/marketplace.json` (Codex) and `plugins/runpod/.codex-plugin/plugin.json` (`interface.category`) keep `"Infrastructure"`. Different registries, no published category set to match, so there's nothing to align them to. Happy to make all three read the same if we'd rather have internal consistency over per-registry fit.

</details>

## Checklist
- [x] Updated the doc(s) this change affects (SKILL.md / reference / golden-path / AGENTS.md), or N/A — N/A, manifest-only
- [x] If a rule/behavior changed, kept it consistent across the router + affected skills — N/A
- [x] Ran the hooks locally: `validate_marketplace` · `check_versions` · `check_runpod_branding` · `check_links` — all pass, plus `claude plugin validate . ` and `--strict` on the plugin
- [x] Did NOT hand-edit versions or `CHANGELOG.md` released sections (release-please owns those)