### PR TITLE
docs(runpod): v2.10.0 surface, source-of-truth posture, and golden paths as step 0 of routing

### DIFF
--- a/.github/workflows/spec-drift.yml
+++ b/.github/workflows/spec-drift.yml
@@ -1,10 +1,13 @@
 name: spec-drift
 
-# The two checks in `validate` run against a vendored spec snapshot, so they gate what
-# a PR changed and nothing else. This job runs the same checks against the *live* API,
-# which is the only way to notice that v2 moved under us. It is deliberately separate
-# and non-blocking: an upstream spec change is real news, but it is not a reason to
-# fail an unrelated PR.
+# The snapshot-backed checks in `validate` gate what a PR changed and nothing else.
+# This job runs the same checks against the *live* API and the latest runpodctl
+# release, which is the only way to notice that upstream moved under us. It is
+# deliberately separate and non-blocking: an upstream change is real news, but it is
+# not a reason to fail an unrelated PR.
+#
+# The runpodctl half exists because a release has twice falsified "the CLI cannot do
+# X" claims in the skills (v2.9.0 -> `serverless health`, v2.10.0 -> `serverless logs`).
 
 on:
   schedule:
@@ -29,3 +32,5 @@ jobs:
         run: python3 hooks/check_migrate_tables.py --live
       - name: Class-3 table vs. live spec
         run: python3 hooks/check_migrate_class3.py --live
+      - name: CLI absence claims vs. the latest runpodctl release
+        run: python3 hooks/check_cli_absence_claims.py --live

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,6 +21,8 @@ jobs:
         run: python3 hooks/check_runpod_branding.py
       - name: Check Markdown links
         run: python3 hooks/check_links.py
+      - name: Check CLI absence claims against the vendored runpodctl surface
+        run: python3 hooks/check_cli_absence_claims.py
       - name: Check runpod-migrate scanner against its corpora
         run: python3 hooks/check_migrate_scanner.py
       - name: Check runpod-migrate path tables against the spec snapshot

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,9 @@ jobs:
       - name: Check Markdown links
         run: python3 hooks/check_links.py
       - name: Check CLI absence claims against the vendored runpodctl surface
-        run: python3 hooks/check_cli_absence_claims.py
+        run: |
+          python3 hooks/check_cli_absence_claims.py --self-test
+          python3 hooks/check_cli_absence_claims.py
       - name: Check runpod-migrate scanner against its corpora
         run: python3 hooks/check_migrate_scanner.py
       - name: Check runpod-migrate path tables against the spec snapshot

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,11 +30,13 @@ plugins/runpod/                   THE plugin
   README.md  CHANGELOG.md
   skills/                         the seven skills (below)
   golden-paths/                   worked end-to-end reference tasks (no SKILL.md)
-hooks/                            validate_marketplace / check_versions / check_runpod_branding / check_links / check_migrate_scanner / check_migrate_tables / check_migrate_class3
+hooks/                            validate_marketplace / check_versions / check_runpod_branding / check_links / check_cli_absence_claims / check_migrate_scanner / check_migrate_tables / check_migrate_class3
+                                  gen_cli_surface.py regenerates the runpodctl snapshot
 testdata/runpod-migrate/          fixture repos the scanner regression check runs against
 testdata/runpod-migrate/v2-openapi.json   vendored v2 spec snapshot the two spec checks gate against
+testdata/runpodctl/command-surface.json   vendored runpodctl command surface the absence check gates against
 .github/workflows/validate.yml    runs the hooks on PRs
-.github/workflows/spec-drift.yml  weekly, non-blocking: the same spec checks against the live API
+.github/workflows/spec-drift.yml  weekly, non-blocking: the same spec checks against the live API + the latest runpodctl release
 ```
 
 ## Architecture: a router + lanes
@@ -126,11 +128,26 @@ editing the repo. Each is its own checkable rule.
    when v2 genuinely changed, and re-read the affected rows when you do. A wrong Class-3
    row is worse than a wrong rename: SKILL.md tells the agent to stop and ask the user
    about those, so it buys an interruption over a decision that does not exist.
-9. **Releases** —
+9. **Never claim a tool cannot do something without checking.** "runpodctl has no X
+   command", "only MCP can Y", "there's no first-class Z" — these are assertions of
+   **absence**, and they are the claims that rot silently. The `--help`-is-authoritative
+   rule does not protect them: there is no flag to look up, so nobody reverifies, and the
+   sentence reads as authoritative until the release that adds the command.
+   - `hooks/check_cli_absence_claims.py` gates every such claim against
+     `testdata/runpodctl/command-surface.json`. When runpodctl releases, run
+     `python3 hooks/gen_cli_surface.py`, then fix whatever the check reports.
+   - Prefer a positive claim ("read them with `serverless logs`") or silence. If an absence
+     claim is genuinely load-bearing, give it a **version floor** ("needs ≥ v2.10.0") rather
+     than an open-ended "cannot", and add it to the check's `ALLOW` list with a reason.
+   - **An eval asserting a false negative is the worst case** — it trains the wrong behavior
+     in rather than merely misinforming a reader. This has already happened twice: v2.9.0
+     added `serverless health` and v2.10.0 added `serverless logs`/`pod logs`, each
+     falsifying claims the skills stated as fact.
+10. **Releases** —
    - Never hand-bump versions; release-please cuts the release (see `CONTRIBUTING.md` →
      Cutting a release).
    - Use Conventional Commits.
-10. **Skill body size** — put only a decision table plus the 80% patterns in a `SKILL.md` body;
+11. **Skill body size** — put only a decision table plus the 80% patterns in a `SKILL.md` body;
    move long tables and deep explanations into `reference/*.md` linked from the body.
 
 ## Conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,9 @@ rule 11): the `SKILL.md` body stays small and long tables / deep explanations li
 - Each golden-path doc uses one section template: Goal · Status · Lane(s) → When to
   use → Prerequisites → Walkthrough → Verify → Gotchas → Cost & cleanup → skill gaps.
 - Each skill's `evals/*.eval.md` are regression scenarios (Prompt / Expected
-  behavior / Assertions).
+  behavior / Assertions). **They are not executed** — no runner exists in this repo and CI
+  does not read them. They are specifications to hand-check a model against and to review
+  when behavior changes; treat "an eval covers it" as documentation, not coverage.
 
 ## Contributor rules
 
@@ -115,7 +117,10 @@ editing the repo. Each is its own checkable rule.
    - Every lane's `SKILL.md` links back to `golden-paths/README.md`. A new lane needs one.
    - Do not widen the trigger to "always read an example first" — a single read or single
      CRUD call should route straight to the lane. `consult-golden-path-first.eval.md`
-     asserts both directions, so widening it breaks that eval on purpose.
+     documents both directions and is the scenario to re-read before changing the trigger.
+     Note that **nothing executes `evals/*.eval.md`** — there is no runner in this repo, so
+     they are review scenarios and hand-check fixtures, not a gate. Do not describe them as
+     enforcing anything.
    - Single approach → one file `NN-name.md`. Multiple variants → a folder
      `NN-name/` with a `README.md` (goal, "which variant?", shared schema/gotchas/cost)
      plus one `variant-*.md` per approach.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ whenever the agent is shell-only). Consult the matrix there; don't rely on this 
 - `compatibility`, `metadata` (author, version), `license`.
 
 The body is markdown the agent consumes, following **progressive disclosure** (see Contributor
-rule 8): the `SKILL.md` body stays small and long tables / deep explanations live in
+rule 11): the `SKILL.md` body stays small and long tables / deep explanations live in
 `reference/*.md` that the body links to and the agent opens only when needed.
 
 ## Golden paths & evals
@@ -105,13 +105,21 @@ editing the repo. Each is its own checkable rule.
    - When it changes, update `skills/runpod/SKILL.md`, `skills/runpod-mcp/SKILL.md`, and
      `skills/runpodctl/SKILL.md` in the same change.
    - State the rule only in `skills/runpod/SKILL.md`; do not restate it elsewhere.
-5. **Golden paths** —
+5. **Golden paths** — they are **step 0 of routing, not an appendix**.
+   `skills/runpod/SKILL.md` tells an agent to match the task against the golden-paths
+   index *before* picking a lane whenever the task spans more than one resource or lane,
+   provisions something billable, is shaped like "get X running", or warrants a multi-step
+   plan. Keep that true, and keep the file conventions:
+   - When you add or rename a path, add its row to **both** the router's "Want to…" table
+     in `skills/runpod/SKILL.md` and the `golden-paths/README.md` table.
+   - Every lane's `SKILL.md` links back to `golden-paths/README.md`. A new lane needs one.
+   - Do not widen the trigger to "always read an example first" — a single read or single
+     CRUD call should route straight to the lane. `consult-golden-path-first.eval.md`
+     asserts both directions, so widening it breaks that eval on purpose.
    - Single approach → one file `NN-name.md`. Multiple variants → a folder
      `NN-name/` with a `README.md` (goal, "which variant?", shared schema/gotchas/cost)
      plus one `variant-*.md` per approach.
    - Every golden-path doc follows the section template listed under *Golden paths & evals*.
-   - When adding or splitting a path, update the `golden-paths/README.md` table in the
-     same change.
    - The per-path verification status is authoritative in `golden-paths/README.md`'s Status
      column; do not restate it in AGENTS.md (it drifts).
 6. **Evals** — add or update an `evals/*.eval.md` when you add or change routing/behavior.

--- a/hooks/check_cli_absence_claims.py
+++ b/hooks/check_cli_absence_claims.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Check the skills' "runpodctl cannot do X" claims against the real CLI surface.
+
+Every claim that a runpodctl command does NOT exist is an assertion of ABSENCE, and
+absence is the one kind of claim that rots silently: `--help` deference does not
+protect it (there is no flag to look up), a reader has no reason to probe, and the
+claim reads as authoritative right up until the release that adds the command.
+
+This has now happened twice in the same skill. v2.9.0 added `serverless health`,
+falsifying "diagnosis relies on /health worker counts"; v2.10.0 added `pod logs` and
+`serverless logs`, falsifying eleven assertions that worker logs were MCP-only —
+including an eval that graded an agent CORRECT for saying so. An eval that asserts a
+false negative is worse than a stale flag list: it trains the behavior in.
+
+So: find the absence claims, extract the command each one names, and fail if that
+command exists in the vendored surface snapshot.
+
+    python3 hooks/check_cli_absence_claims.py         # vendored snapshot (CI gate)
+    python3 hooks/check_cli_absence_claims.py --live  # latest release (drift job)
+
+Exit 1 if any absence claim names a command that exists.
+"""
+from __future__ import annotations
+import argparse, json, re, subprocess, sys, tempfile, urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SKILLS = ROOT / "plugins/runpod/skills"
+SNAPSHOT = ROOT / "testdata/runpodctl/command-surface.json"
+
+# Sentences that assert a runpodctl command is missing. Deliberately narrow: it must
+# name runpodctl (or "the CLI"/"the CLI lane") AND use absence wording. Broad matching
+# here produces noise that gets the whole check disabled.
+ABSENCE = re.compile(
+    r"(?:runpodctl|the CLI(?: lane)?|CLI lane)[^.\n]{0,120}?"
+    r"\b(?:has no|have no|has never had|lacks|cannot|can't|is unable to|no first-class|"
+    r"there is no|there's no|no (?:such )?(?:\w+[- ])?command)\b"
+    r"[^.\n]{0,160}"
+    r"|\b(?:has no|there is no|there's no|no first-class)\b[^.\n]{0,80}?"
+    r"\bcommand\b[^.\n]{0,60}?\bin (?:runpodctl|the CLI)\b",
+    re.IGNORECASE,
+)
+
+# "only MCP can X" is the same claim from the other side.
+MCP_ONLY = re.compile(
+    r"\b(?:only|sole)\b[^.\n]{0,60}\bMCP\b[^.\n]{0,120}"
+    r"|\bMCP[- ]only\b[^.\n]{0,120}"
+    r"|\bthe (?:only|one) (?:lane|tool lane|route)\b[^.\n]{0,120}",
+    re.IGNORECASE,
+)
+
+# A claim only falsifies if it names a real command path. `<verb> <noun>` pairs like
+# "worker-log command" are not command paths; these are.
+RESOURCES = r"pod|serverless|sls|template|tpl|hub|model|network-volume|nv|registry|reg|user|gpu|datacenter|dc|billing|doctor|ssh|send|receive|update|version"
+CMD_IN_TEXT = re.compile(rf"\b({RESOURCES})\s+([a-z][a-z-]+)\b")
+
+# Absence claims that are true and must stay allowed. Each needs a reason: this list is
+# how a legitimate "MCP has no tool for this" survives the check, not an escape hatch for
+# a claim nobody rechecked.
+ALLOW = {
+    # (substring that must appear in the matched text, why it is allowed)
+    "MCP has no tool for these": "about MCP's surface, not runpodctl's",
+    "no worker-log path on REST v1": "about REST v1, not runpodctl",
+    "v1 has no worker-log path at all": "about REST v1, not runpodctl",
+    "MCP narrows to one GPU type": "about MCP's surface",
+    "no CPU concept": "about MCP's surface",
+    "cannot change it": "about the API, not a missing command",
+    "cannot express a SKU": "about MCP's surface",
+    "can't change the tier": "about the API",
+    "no type field": "about REST v1 / the API shape",
+    "OAuth": "MCP-only auth mode, genuinely MCP-only",
+    "CLIs stay unauthed": "MCP-only auth mode",
+    "stream-job": "incremental job output is genuinely MCP-only",
+    "no `--gpu-id` flag": "a missing flag, which --help does cover",
+    "no table format": "a missing flag value, covered by output-and-errors.md",
+}
+
+
+def load_surface(live: bool) -> tuple[str, set[str]]:
+    if not live:
+        snap = json.loads(SNAPSHOT.read_text())
+        return snap["version"], set(snap["commands"]) | set(snap.get("hidden_commands", []))
+    tag = json.load(urllib.request.urlopen(
+        "https://api.github.com/repos/runpod/runpodctl/releases/latest"))["tag_name"]
+    import platform
+    arch = "arm64" if platform.machine() in ("arm64", "aarch64") else "amd64"
+    osname = "darwin" if sys.platform == "darwin" else "linux"
+    url = f"https://github.com/runpod/runpodctl/releases/download/{tag}/runpodctl-{osname}-{arch}"
+    with tempfile.NamedTemporaryFile(delete=False, suffix="-runpodctl") as fh:
+        fh.write(urllib.request.urlopen(url).read())
+        binp = fh.name
+    Path(binp).chmod(0o755)
+    cmds: set[str] = set()
+
+    def walk(path: str) -> None:
+        out = subprocess.run([binp] + path.split() + ["--help"],
+                             capture_output=True, text=True).stdout
+        seen = False
+        for ln in out.splitlines():
+            if ln.startswith("Available Commands:"):
+                seen = True
+                continue
+            if seen and ln.startswith(("Flags:", "Global Flags:")):
+                break
+            if seen:
+                m = re.match(r"\s+(\S+)\s", ln)
+                if m and m.group(1) not in ("help", "completion"):
+                    child = f"{path} {m.group(1)}".strip()
+                    cmds.add(child)
+                    walk(child)
+
+    walk("")
+    return tag, cmds
+
+
+# A claim that a command lacks a FLAG or a field is not an absence-of-command claim.
+# `--help` covers those, which is the whole reason this check only guards commands.
+FLAG_CLAIM = re.compile(r"--[a-z][a-z0-9-]*|\b(?:flag|field|param(?:eter)?|option|key)s?\b",
+                        re.IGNORECASE)
+# "no longer MCP-only", "is not the only lane" — the claim is being retired, not made.
+NEGATED = re.compile(r"\b(?:no longer|not (?:an? )?(?:the )?only|used to be|"
+                     r"is no longer|stopped being|until v?\d|before v?\d|as of v?\d)\b",
+                     re.IGNORECASE)
+
+
+def allowed(text: str, line: str = "") -> str | None:
+    # negation often sits just outside the matched span ("no longer an MCP-only capability"),
+    # so judge it on the whole line.
+    if NEGATED.search(line or text):
+        return "negated / historical — the claim is being retired, not asserted"
+    if FLAG_CLAIM.search(text):
+        return "about a missing flag or field, which --help covers"
+    for needle, why in ALLOW.items():
+        if needle.lower() in text.lower():
+            return why
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--live", action="store_true",
+                    help="check against the latest runpodctl release instead of the snapshot")
+    args = ap.parse_args()
+
+    version, commands = load_surface(args.live)
+    # index by "<resource> <action>" and by alias-expanded form
+    exists = set(commands)
+
+    failures, notes = [], []
+    for path in sorted(SKILLS.rglob("*.md")):
+        rel = path.relative_to(ROOT)
+        for n, line in enumerate(path.read_text().splitlines(), 1):
+            for rx in (ABSENCE, MCP_ONLY):
+                for m in rx.finditer(line):
+                    text = m.group(0)
+                    why = allowed(text, line)
+                    if why:
+                        continue
+                    named = {f"{r} {a}" for r, a in CMD_IN_TEXT.findall(text)}
+                    hits = sorted(named & exists)
+                    if hits:
+                        failures.append((rel, n, text.strip(), hits))
+                    else:
+                        notes.append((rel, n, text.strip()))
+
+    if failures:
+        print(f"CLI absence-claim check FAILED against runpodctl {version}:\n")
+        for rel, n, text, hits in failures:
+            print(f"  {rel}:{n}")
+            print(f"    claims absence: {text[:150]}")
+            print(f"    but these exist: {', '.join('runpodctl ' + h for h in hits)}\n")
+        print("Fix the claim. If it is genuinely still true, add it to ALLOW with a reason.")
+        return 1
+
+    print(f"CLI absence-claim check OK against runpodctl {version} "
+          f"({len(notes)} absence claim(s) reviewed, none name an existing command)")
+    if args.live:
+        for rel, n, text in notes:
+            print(f"  note {rel}:{n}  {text[:110]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/check_cli_absence_claims.py
+++ b/hooks/check_cli_absence_claims.py
@@ -49,10 +49,23 @@ MCP_ONLY = re.compile(
     re.IGNORECASE,
 )
 
+# "you must use MCP for X" / "X requires the MCP server" is an absence claim with no
+# absence wording in it — the form that slipped past the first two patterns.
+MUST_USE_MCP = re.compile(
+    r"\b(?:must use|have to use|need(?:s)? (?:to use )?|requires?"
+    r"|only\b[^.\n]{0,24}?\b(?:via|through|with|from|in))\b"
+    r"[^.\n]{0,60}\b(?:MCP|Console)\b[^.\n]{0,80}"
+    r"|\b(?:MCP|Console)\b[^.\n]{0,40}\bis (?:the )?(?:only|required)\b[^.\n]{0,80}",
+    re.IGNORECASE,
+)
+
 # A claim only falsifies if it names a real command path. `<verb> <noun>` pairs like
 # "worker-log command" are not command paths; these are.
 RESOURCES = r"pod|serverless|sls|template|tpl|hub|model|network-volume|nv|registry|reg|user|gpu|datacenter|dc|billing|doctor|ssh|send|receive|update|version"
-CMD_IN_TEXT = re.compile(rf"\b({RESOURCES})\s+([a-z][a-z-]+)\b")
+# Case-insensitive: a claim that opens a sentence capitalizes the resource
+# ("Serverless logs are only available through MCP"), and a case-sensitive match
+# let exactly that phrasing through.
+CMD_IN_TEXT = re.compile(rf"\b({RESOURCES})\s+([a-z][a-z-]+)\b", re.IGNORECASE)
 
 # Absence claims that are true and must stay allowed. Each needs a reason: this list is
 # how a legitimate "MCP has no tool for this" survives the check, not an escape hatch for
@@ -60,6 +73,7 @@ CMD_IN_TEXT = re.compile(rf"\b({RESOURCES})\s+([a-z][a-z-]+)\b")
 ALLOW = {
     # (substring that must appear in the matched text, why it is allowed)
     "MCP has no tool for these": "about MCP's surface, not runpodctl's",
+    "MCP rejects that combination": "about MCP's surface, not runpodctl's",
     "no worker-log path on REST v1": "about REST v1, not runpodctl",
     "v1 has no worker-log path at all": "about REST v1, not runpodctl",
     "MCP narrows to one GPU type": "about MCP's surface",
@@ -115,8 +129,11 @@ def load_surface(live: bool) -> tuple[str, set[str]]:
 
 # A claim that a command lacks a FLAG or a field is not an absence-of-command claim.
 # `--help` covers those, which is the whole reason this check only guards commands.
-FLAG_CLAIM = re.compile(r"--[a-z][a-z0-9-]*|\b(?:flag|field|param(?:eter)?|option|key)s?\b",
-                        re.IGNORECASE)
+FLAG_CLAIM = re.compile(
+    r"--[a-z][a-z0-9-]*"                      # a literal flag
+    r"|\b(?:flag|field|param(?:eter)?|option|key|support)s?\b"
+    r"|`[a-z]+[A-Z]\w*`",                     # a backticked camelCase api field, e.g. `templateId`
+    re.IGNORECASE)
 # "no longer MCP-only", "is not the only lane" — the claim is being retired, not made.
 NEGATED = re.compile(r"\b(?:no longer|not (?:an? )?(?:the )?only|used to be|"
                      r"is no longer|stopped being|until v?\d|before v?\d|as of v?\d)\b",
@@ -136,32 +153,86 @@ def allowed(text: str, line: str = "") -> str | None:
     return None
 
 
+# Phrasings that MUST fail, and legitimate ones that MUST NOT. A pattern tweak that
+# quietly stops catching a form is the failure mode this check cannot afford, and every
+# MUST_CATCH line below is a phrasing that actually evaded an earlier version of these
+# regexes. Run with --self-test (CI does).
+MUST_CATCH = [
+    "runpodctl has no serverless logs command.",
+    "There is no pod logs command in runpodctl.",
+    "The CLI lane cannot read serverless logs.",
+    "Only MCP can do serverless logs.",
+    "Worker logs are MCP-only; runpodctl serverless logs does not exist.",
+    "runpodctl is unable to do serverless logs.",
+    "runpodctl lacks a serverless logs subcommand.",
+    "For pod logs you must use the MCP server.",
+    "Reading serverless logs requires the MCP server.",
+    "Serverless logs are only available through MCP.",
+    "Pod logs require the Console.",
+]
+MUST_ALLOW = [
+    "serverless update has no --gpu-id flag.",
+    "MCP create-endpoint lacks templateId support for pod create.",
+    "serverless logs needs runpodctl >= v2.10.0.",
+    "Logs are no longer MCP-only: runpodctl serverless logs exists.",
+    "MCP has no tool for send or receive.",
+]
+
+
+def self_test(commands: set[str]) -> int:
+    bad = []
+    for claim in MUST_CATCH:
+        if not scan_line(claim, commands):
+            bad.append(("should have been caught", claim))
+    for claim in MUST_ALLOW:
+        if scan_line(claim, commands):
+            bad.append(("should have been exempt", claim))
+    for why, claim in bad:
+        print(f"  self-test: {why}: {claim}")
+    if bad:
+        print(f"self-test FAILED ({len(bad)} of "
+              f"{len(MUST_CATCH) + len(MUST_ALLOW)} cases)")
+        return 1
+    print(f"self-test OK ({len(MUST_CATCH)} caught, {len(MUST_ALLOW)} exempt)")
+    return 0
+
+
+def scan_line(line: str, commands: set[str]) -> list[str]:
+    """Return the existing commands a line's absence claims name, or []."""
+    hits: set[str] = set()
+    for rx in (ABSENCE, MCP_ONLY, MUST_USE_MCP):
+        for m in rx.finditer(line):
+            if allowed(m.group(0), line):
+                continue
+            named = {f"{r.lower()} {a.lower()}" for r, a in CMD_IN_TEXT.findall(line)}
+            hits |= named & commands
+    return sorted(hits)
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--live", action="store_true",
                     help="check against the latest runpodctl release instead of the snapshot")
+    ap.add_argument("--self-test", action="store_true",
+                    help="verify the patterns still catch known-bad phrasings")
     args = ap.parse_args()
 
     version, commands = load_surface(args.live)
     # index by "<resource> <action>" and by alias-expanded form
     exists = set(commands)
 
+    if args.self_test:
+        return self_test(exists)
+
     failures, notes = [], []
     for path in sorted(SKILLS.rglob("*.md")):
         rel = path.relative_to(ROOT)
         for n, line in enumerate(path.read_text().splitlines(), 1):
-            for rx in (ABSENCE, MCP_ONLY):
-                for m in rx.finditer(line):
-                    text = m.group(0)
-                    why = allowed(text, line)
-                    if why:
-                        continue
-                    named = {f"{r} {a}" for r, a in CMD_IN_TEXT.findall(text)}
-                    hits = sorted(named & exists)
-                    if hits:
-                        failures.append((rel, n, text.strip(), hits))
-                    else:
-                        notes.append((rel, n, text.strip()))
+            hits = scan_line(line, exists)
+            if hits:
+                failures.append((rel, n, line.strip(), hits))
+            elif any(rx.search(line) for rx in (ABSENCE, MCP_ONLY, MUST_USE_MCP)):
+                notes.append((rel, n, line.strip()))
 
     if failures:
         print(f"CLI absence-claim check FAILED against runpodctl {version}:\n")

--- a/hooks/gen_cli_surface.py
+++ b/hooks/gen_cli_surface.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Regenerate testdata/runpodctl/command-surface.json from a runpodctl binary.
+
+    python3 hooks/gen_cli_surface.py                    # use `runpodctl` on PATH
+    python3 hooks/gen_cli_surface.py --bin ./runpodctl  # a specific build
+
+Refresh this when runpodctl cuts a release, then re-run
+hooks/check_cli_absence_claims.py and fix whatever it now reports. The snapshot is
+the gate's source of truth precisely so a release cannot quietly falsify a doc.
+"""
+from __future__ import annotations
+import argparse, json, re, subprocess, sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+OUT = ROOT / "testdata/runpodctl/command-surface.json"
+# Deprecated paths cobra hides from --help but still serves. Absence claims about them
+# would be wrong too, so they are part of the surface.
+HIDDEN = ["get pod", "get cloud", "create pod", "remove pod", "exec", "project", "config"]
+
+
+def run(binp: str, path: str, *extra: str) -> str:
+    return subprocess.run([binp] + path.split() + list(extra),
+                          capture_output=True, text=True).stdout
+
+
+def subcommands(binp: str, path: str) -> list[str]:
+    out, seen, found = run(binp, path, "--help"), False, []
+    for ln in out.splitlines():
+        if ln.startswith("Available Commands:"):
+            seen = True
+            continue
+        if seen and ln.startswith(("Flags:", "Global Flags:")):
+            break
+        if seen:
+            m = re.match(r"\s+(\S+)\s", ln)
+            if m and m.group(1) not in ("help", "completion"):
+                found.append(m.group(1))
+    return found
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bin", default="runpodctl")
+    args = ap.parse_args()
+    version = run(args.bin, "version").strip()
+    if not version:
+        print(f"could not run {args.bin!r}", file=sys.stderr)
+        return 1
+
+    cmds: dict[str, dict] = {}
+    for top in subcommands(args.bin, ""):
+        for path in [top] + [f"{top} {s}" for s in subcommands(args.bin, top)]:
+            out = run(args.bin, path, "--help")
+            alias = re.search(r"Aliases:\n\s+(.+)", out)
+            cmds[path] = {
+                "flags": sorted(set(re.findall(r"(--[a-z][a-z0-9-]+)", out))),
+                "aliases": [a.strip() for a in alias.group(1).split(",")] if alias else [],
+            }
+
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    OUT.write_text(json.dumps({
+        "_comment": "Vendored runpodctl command surface. Regenerate with "
+                    "hooks/gen_cli_surface.py against a released binary. "
+                    "Gates hooks/check_cli_absence_claims.py.",
+        "version": version,
+        "hidden_commands": HIDDEN,
+        "commands": cmds,
+    }, indent=2, sort_keys=True) + "\n")
+    print(f"wrote {OUT.relative_to(ROOT)} — {version}, {len(cmds)} commands")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/runpod/README.md
+++ b/plugins/runpod/README.md
@@ -36,11 +36,55 @@ pod vs serverless → prefer a prebuilt template/Hub worker over from-scratch �
 provision → verify with a real request ("Running" ≠ "ready") → deliver → cost-guard
 + teardown.** See [`skills/runpod-usage/reference/development-loop.md`](skills/runpod-usage/reference/development-loop.md).
 
-The [`skills/runpod/golden-paths/`](skills/runpod/golden-paths/) folder holds
-worked, end-to-end reference tasks (Ollama, ComfyUI, Whisper, …) — acceptance
-scenarios, not installed skills (they have no `SKILL.md`, so agents don't load
-them). They live under the `runpod` router skill that indexes them, so they
-travel with it on a single-skill install.
+## Golden paths — check these first
+
+**Before improvising a deployment, look for a golden path that already covers it.**
+[`skills/runpod/golden-paths/`](skills/runpod/golden-paths/README.md) holds worked,
+end-to-end reference tasks — Ollama and ComfyUI on pods, a Whisper endpoint,
+fine-tune → serve, network-volume handoffs, autoscaling, streaming, webhooks,
+host-cached HF models, and observability, among others. Nearly all are
+**live-verified**: someone ran the whole thing on real infrastructure and pasted back
+the actual output, including the parts that went wrong. The index marks the status of
+each.
+
+They are worth the detour because they encode the failure modes you would otherwise
+hit yourself — the "Running ≠ ready" trap, data-center pinning, cold-start costs,
+and cleanup. Point your agent at one directly:
+
+> "Follow golden path 20 to deploy this HuggingFace model."
+
+They are acceptance scenarios, not installed skills (no `SKILL.md`, so agents don't
+auto-load them), and they live under the `runpod` router skill that indexes them, so
+they travel with it on a single-skill install.
+
+## Getting a model onto a worker
+
+If the model is **on HuggingFace, and you are deploying GPU serverless**, prefer
+Runpod's host-side model cache over a network volume:
+
+```bash
+runpodctl serverless create --template-id <id> --gpu-id "NVIDIA GeForce RTX 4090" \
+  --model-reference https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct:main
+```
+
+Runpod caches the weights on the host, so workers start on machines that already
+hold the model — cold starts drop to seconds and **you are not billed for download
+time**. Weights land in the standard HF cache layout
+(`/runpod-volume/huggingface-cache/hub/`), so Transformers, vLLM, and anything else
+that reads that cache picks them up with no handler changes. A network volume, by
+contrast, is **pinned to one data center**, which narrows the GPU availability you
+can schedule against.
+
+Reach for the other options deliberately: a **network volume** when you want direct
+filesystem control or are sharing large files across workers, the **Model
+Repository** (`runpodctl model add`) for your own artifacts that aren't on
+HuggingFace, and **baking into the image** when you need a fully reproducible build.
+Caching is GPU-only and needs `runpodctl` ≥ v2.4.0.
+
+Full comparison and commands:
+[`runpodctl/reference/model-caching.md`](skills/runpodctl/reference/model-caching.md).
+Worked example: golden path
+[20 — host-cached HF model endpoint](skills/runpod/golden-paths/20-model-caching-endpoint.md).
 
 ## Setup
 

--- a/plugins/runpod/skills/companion-clis/SKILL.md
+++ b/plugins/runpod/skills/companion-clis/SKILL.md
@@ -22,6 +22,12 @@ Four CLIs commonly needed alongside Runpod. Each has its own **credentials + com
 
 Each requires credentials before use. Read the per-tool reference for auth steps and commands; install is a separate one-time `<cli>-setup.md`.
 
+These CLIs are usually one step inside a larger job. For the whole job the verified example is
+in [runpod/golden-paths/README.md](../runpod/golden-paths/README.md) — baking vs mounting a
+model ([25](../runpod/golden-paths/25-bake-vs-mount/README.md)), building a minimal image
+([22](../runpod/golden-paths/22-minimal-pod-image/README.md)), or moving data to a network
+volume ([07](../runpod/golden-paths/07-network-volume-handoff.md)).
+
 These are third-party CLIs on their own release trains, so **`<cli> --help` is authoritative
 for flags and subcommands** — the references here cover the Runpod-specific usage and the
 traps, not the tool's full surface. Check `--help` before reporting that one of them cannot do

--- a/plugins/runpod/skills/companion-clis/SKILL.md
+++ b/plugins/runpod/skills/companion-clis/SKILL.md
@@ -22,6 +22,11 @@ Four CLIs commonly needed alongside Runpod. Each has its own **credentials + com
 
 Each requires credentials before use. Read the per-tool reference for auth steps and commands; install is a separate one-time `<cli>-setup.md`.
 
+These are third-party CLIs on their own release trains, so **`<cli> --help` is authoritative
+for flags and subcommands** — the references here cover the Runpod-specific usage and the
+traps, not the tool's full surface. Check `--help` before reporting that one of them cannot do
+something.
+
 ## Windows: Install WSL2 First
 
 If you are on Windows, install WSL2 before proceeding — it gives you the native Linux environment all these CLIs target. In PowerShell as Administrator, then restart:

--- a/plugins/runpod/skills/flash/SKILL.md
+++ b/plugins/runpod/skills/flash/SKILL.md
@@ -22,6 +22,13 @@ are authoritative for the command surface** — this skill is the mental model, 
 rules, and the gotchas that help output does not carry. Confirm the installed version with
 `pip show runpod-flash` before concluding a subcommand or flag is unavailable.
 
+**Worked examples first for anything multi-step.** Flash appears in verified end-to-end
+paths — [03 variant B (whisper endpoint via flash)](../runpod/golden-paths/03-whisper-endpoint/variant-b-flash.md)
+and [08 (fine-tune → serve)](../runpod/golden-paths/08-finetune-to-serverless.md); the full
+index is [runpod/golden-paths/README.md](../runpod/golden-paths/README.md). Open the matching
+path before planning a deploy — it carries the ordering and the cost cleanup this skill only
+summarizes.
+
 **Load on demand — this skill keeps the mental model + gotchas inline; details live in [`reference/`](reference/):**
 
 | Need | Read |

--- a/plugins/runpod/skills/flash/SKILL.md
+++ b/plugins/runpod/skills/flash/SKILL.md
@@ -17,6 +17,11 @@ license: Apache-2.0
 
 Write code locally, iterate with `flash dev` — it runs your functions on remote Runpod GPUs/CPUs with hot-reload and live worker logs — then `flash deploy` to ship. `Endpoint` handles provisioning.
 
+`runpod-flash` releases on its own cadence, so **`flash --help` and `flash <command> --help`
+are authoritative for the command surface** — this skill is the mental model, the decision
+rules, and the gotchas that help output does not carry. Confirm the installed version with
+`pip show runpod-flash` before concluding a subcommand or flag is unavailable.
+
 **Load on demand — this skill keeps the mental model + gotchas inline; details live in [`reference/`](reference/):**
 
 | Need | Read |

--- a/plugins/runpod/skills/runpod-mcp/SKILL.md
+++ b/plugins/runpod/skills/runpod-mcp/SKILL.md
@@ -67,6 +67,7 @@ Structured tools, grouped by resource:
 
 - **Pods** — list, get, create, update, start, stop, restart, delete, stream logs.
 - **Serverless endpoints** — list, get, create, update, delete; list workers; list releases; stream worker logs.
+  - **Logs are no longer an MCP-only capability** — runpodctl grew `pod logs` and `serverless logs` in v2.10.0. MCP still returns already-parsed, bounded frames, which is the easier shape inside an agent; reach for the CLI when you are shell-only or want `--follow`. Job *output* streaming (`stream-job`) remains MCP-only.
   - `create-endpoint` takes `endpointType: QUEUE` (default) or `LOAD_BALANCER` — see golden path 14. The routing type is fixed at creation; `update-endpoint` cannot change it.
   - Read an endpoint's invoke URLs from `requestUrls` on the get/list reply instead of assembling them.
   - To pin a specific GPU **SKU** on an existing endpoint use `set-endpoint-gpus`; `create-endpoint`/`update-endpoint` expose only `gpuPoolIds` and can't express a SKU (`deploy-hub-repo` can pin one at deploy time via `gpuIds` exclusions).

--- a/plugins/runpod/skills/runpod-mcp/SKILL.md
+++ b/plugins/runpod/skills/runpod-mcp/SKILL.md
@@ -23,6 +23,12 @@ so an MCP-capable agent can manage infrastructure without shelling out. It is th
 same Runpod REST API that `runpodctl` uses — pick MCP when its tools are
 connected (typed params, structured errors, no shell quoting).
 
+**For a multi-step job, read the worked example before calling tools.** Tool calls are easy
+to issue and easy to issue in the wrong order — the verified end-to-end sequences live in
+[runpod/golden-paths/README.md](../runpod/golden-paths/README.md) (image → template →
+endpoint, pod → volume → serverless, multi-region, autoscaling, monitoring). This skill
+covers what each tool does; the paths cover what order to do them in and what it costs.
+
 ## Connect
 
 Connect the hosted server with **your API key as a Bearer header** if you also use runpodctl/flash — that one key auths the MCP *and* the CLIs (the 80% path):

--- a/plugins/runpod/skills/runpod-usage/SKILL.md
+++ b/plugins/runpod/skills/runpod-usage/SKILL.md
@@ -19,6 +19,11 @@ Background knowledge for making the right choice before you act. This skill runs
 nothing — once you know what to do, execute with **runpod-mcp**/**runpodctl**
 (infra), **flash** (your own code), or **companion-clis** (models/images/data).
 
+**This skill explains; the golden paths demonstrate.** When the question is really "how do I
+do X" rather than "how does X work", the verified end-to-end example is the faster answer —
+[runpod/golden-paths/README.md](../runpod/golden-paths/README.md). Read the concept here, then
+follow the path.
+
 Read the one reference file that matches the question:
 
 | Question | Read |

--- a/plugins/runpod/skills/runpod-usage/reference/endpoint-workflows.md
+++ b/plugins/runpod/skills/runpod-usage/reference/endpoint-workflows.md
@@ -42,8 +42,11 @@ single-DC pin on a scarce GPU leaves workers `throttled` and jobs stuck `IN_QUEU
 Prefer an **actively-maintained** worker on a **broad, high-availability GPU pool**
 — don't pin a scarce large tier a small model doesn't need. If deployed workers go
 `ready` but jobs sit `IN_QUEUE` with `inProgress: 0`, the image is broken /
-mis-dispatching — **switch workers, don't wait it out.** (There's no first-class
-serverless worker-log command; diagnose via `/health` worker counts — `runpodctl serverless health <id>` reads them for you, v2.9.0+, and the MCP lane can stream worker logs.)
+mis-dispatching — **switch workers, don't wait it out.** (Confirm it before switching:
+`runpodctl serverless health <id>` for the counts (v2.9.0+) and `runpodctl serverless logs
+<id> --source system` for the cause (v2.10.0+) — repeated `start container` with no
+`container` output is a crash loop, not a capacity problem. MCP `stream-worker-logs` reads
+the same logs.)
 
 ## 3. Invoke
 

--- a/plugins/runpod/skills/runpod-usage/reference/endpoint-workflows.md
+++ b/plugins/runpod/skills/runpod-usage/reference/endpoint-workflows.md
@@ -43,9 +43,14 @@ Prefer an **actively-maintained** worker on a **broad, high-availability GPU poo
 — don't pin a scarce large tier a small model doesn't need. If deployed workers go
 `ready` but jobs sit `IN_QUEUE` with `inProgress: 0`, the image is broken /
 mis-dispatching — **switch workers, don't wait it out.** (There's no first-class
-serverless worker-log command; diagnose via `/health` worker counts.)
+serverless worker-log command; diagnose via `/health` worker counts — `runpodctl serverless health <id>` reads them for you, v2.9.0+, and the MCP lane can stream worker logs.)
 
 ## 3. Invoke
+
+The raw protocol is below because it is what you hand a user for copy-paste, and what a
+non-Runpod client speaks. If you are driving it yourself, the tool lanes wrap it:
+`runpodctl serverless run <id> --input '{...}'` (v2.9.0+) does submit-and-poll with auth,
+local payload validation and bounded waiting; the MCP lane has typed job tools.
 
 ```bash
 # warm / small payloads (sync, 60s window):

--- a/plugins/runpod/skills/runpod-usage/reference/gotchas.md
+++ b/plugins/runpod/skills/runpod-usage/reference/gotchas.md
@@ -154,8 +154,10 @@ symptom → cause → fix. See `docker.md` and `storage.md` for the full mechani
   scarce GPU pool the model doesn't need.
 - **Fix:** switch to a different (maintained) Hub worker on a **broad, high-
   availability GPU pool** — don't wait it out. Diagnose via the endpoint `/health`
-  worker counts (there's no first-class serverless worker-log command in runpodctl/
-  REST v1; the MCP server does expose `stream-pod-logs`/worker log streaming).
+  worker counts — `runpodctl serverless health <id>` reads them for you (v2.9.0+) —
+  and then read the worker logs. There is no serverless worker-log command in
+  runpodctl and no worker-log path on REST v1; use the MCP `stream-worker-logs`
+  tool, the v2 REST logs path, or the Console Workers tab.
 
 ## Serverless job goes `IN_PROGRESS` then times out
 

--- a/plugins/runpod/skills/runpod-usage/reference/storage.md
+++ b/plugins/runpod/skills/runpod-usage/reference/storage.md
@@ -15,6 +15,12 @@ Use the faster, non-persistent layers deliberately, not by default: container /
 ephemeral disk for throwaway scratch, and pod volume disk when a single pod's data
 doesn't need to outlive it. When in doubt, choose the network volume.
 
+**One exception: model weights for GPU serverless.** If the model is on HuggingFace,
+the host-side cache beats a volume — faster cold starts, no download billing, and no
+data-center pin narrowing your GPU availability. See
+[Getting a model to the worker](#getting-a-model-to-the-worker) below; the default
+above is about datasets, checkpoints, and everything else worth keeping.
+
 ## The three layers
 
 ### Container / ephemeral disk
@@ -67,8 +73,10 @@ runpodctl). **Do not write to one volume from multiple workers concurrently** �
 
 ## Getting a model to the worker
 
-Three ways to make a model available; choose by size, privacy, and how often it
-changes.
+Four ways to make a model available; choose by size, privacy, and how often it
+changes. On HuggingFace and running GPU serverless → **cached model**; your own
+artifact → **Model Repository** (or a volume if you want to manage the files
+yourself); need a reproducible image → **bake**.
 
 | Option | How | Best when |
 | --- | --- | --- |

--- a/plugins/runpod/skills/runpod/SKILL.md
+++ b/plugins/runpod/skills/runpod/SKILL.md
@@ -3,11 +3,10 @@ name: runpod
 description: >-
   Start here for any Runpod task — running GPU/CPU pods, deploying serverless
   endpoints, templates, network volumes, building images, or understanding how
-  Runpod works. Routes the request to the right Runpod skill (runpod-mcp,
-  runpodctl, flash, companion-clis, or runpod-usage) and indexes 25 verified
-  end-to-end worked examples (golden paths) to follow instead of re-deriving a
-  multi-step task. Use when it is unclear which Runpod skill applies, and for any
-  multi-step or provisioning task even when the lane is obvious.
+  Runpod works. Routes to the right skill (runpod-mcp, runpodctl, flash,
+  companion-clis, runpod-usage, runpod-migrate) and indexes two dozen live-verified
+  end-to-end examples (golden paths) — use it when the lane is unclear, and for any
+  multi-step or provisioning task even when it is not.
 metadata:
   author: runpod
   version: "1.2.0" # x-release-please-version

--- a/plugins/runpod/skills/runpod/SKILL.md
+++ b/plugins/runpod/skills/runpod/SKILL.md
@@ -98,7 +98,8 @@ Capability matrix (pick the preferred lane per operation):
 | Create a pod with a **multi-GPU priority list**, or **template + CPU together** | **runpodctl** | MCP narrows to one GPU type, and rejects a template deploy for a CPU pod |
 | Deploy from the **Hub** | **runpod-mcp** if connected, else runpodctl | MCP has `list-hub-repos` + `deploy-hub-repo` |
 | **File transfer** (`send`/`receive`), **SSH** keys/info, **`doctor`** setup, **model** cache | **runpodctl** | MCP has no tool for these |
-| Invoke a serverless job (`run`/`runsync`/status/stream) | **runpod-mcp** if connected, else runpodctl | Both lanes have first-class job commands now (runpodctl `serverless run`/`status`/`health`, v2.9.0+); MCP is typed, and only MCP streams job output and worker logs |
+| Invoke a serverless job (`run`/`runsync`/status/stream) | **runpod-mcp** if connected, else runpodctl | Both lanes have first-class job commands now (runpodctl `serverless run`/`status`/`health`, v2.9.0+); MCP is typed, and only MCP streams a job's incremental output (`stream-job`) |
+| Read **pod or worker logs** | **either** — runpod-mcp if connected, else runpodctl | Both lanes read them: MCP `stream-pod-logs`/`stream-worker-logs` return parsed frames; runpodctl `pod logs`/`serverless logs` emit json lines and `--follow` (v2.10.0+) |
 
 Rule of thumb: **default to MCP for the easy stuff, hand off to runpodctl the
 moment an op needs a flag/feature MCP doesn't expose.**

--- a/plugins/runpod/skills/runpod/SKILL.md
+++ b/plugins/runpod/skills/runpod/SKILL.md
@@ -98,7 +98,7 @@ Capability matrix (pick the preferred lane per operation):
 | Create a pod with a **multi-GPU priority list**, or **template + CPU together** | **runpodctl** | MCP narrows to one GPU type, and rejects a template deploy for a CPU pod |
 | Deploy from the **Hub** | **runpod-mcp** if connected, else runpodctl | MCP has `list-hub-repos` + `deploy-hub-repo` |
 | **File transfer** (`send`/`receive`), **SSH** keys/info, **`doctor`** setup, **model** cache | **runpodctl** | MCP has no tool for these |
-| Invoke a serverless job (`run`/`runsync`/status/stream) | **runpod-mcp** if connected, else runpodctl | MCP has first-class job tools |
+| Invoke a serverless job (`run`/`runsync`/status/stream) | **runpod-mcp** if connected, else runpodctl | Both lanes have first-class job commands now (runpodctl `serverless run`/`status`/`health`, v2.9.0+); MCP is typed, and only MCP streams job output and worker logs |
 
 Rule of thumb: **default to MCP for the easy stuff, hand off to runpodctl the
 moment an op needs a flag/feature MCP doesn't expose.**

--- a/plugins/runpod/skills/runpod/SKILL.md
+++ b/plugins/runpod/skills/runpod/SKILL.md
@@ -28,6 +28,26 @@ the right lane and hands off. Read the matching skill's `SKILL.md` next.
 | **runpod-usage** | **Understand** how Runpod works before acting — pods vs serverless, building a container, storage, GPU selection, gotchas. Knowledge only. |
 | **runpod-migrate** | **Move existing code** off the GraphQL API or REST v1 onto REST v2 — inventory which parts use which version, rewrite call sites, flag breaking changes. Edits the user's code; does not manage infra. |
 
+## These skills are a snapshot; the tools are the source of truth
+
+Every lane below wraps something that ships on its own release train and moves faster than
+this repo. So route with these skills, but **take capability and syntax from the tool in front
+of you**:
+
+| Lane | Ask it directly |
+| --- | --- |
+| runpodctl | `runpodctl --help`, `runpodctl <resource> <action> --help`, `runpodctl version`. For failure shapes, run a command wrong on purpose and read the JSON |
+| runpod-mcp | your client's tool list (`/mcp` in Claude Code) — each tool carries its own parameter descriptions |
+| flash | `flash --help`, and the deploy/dev output |
+| companion-clis | that CLI's own `--help` (`hf`, `gh`, `docker`, `aws`) |
+| REST v2 | the live spec at `https://api.runpod.io/v2/openapi.json` |
+
+**Never tell a user a tool cannot do something without checking first.** A missing capability
+is the claim most likely to be out of date here, and it is the one a reader has no reason to
+reverify — it has already gone stale twice (runpodctl v2.9.0 added `serverless health`, v2.10.0
+added `pod logs`/`serverless logs`). If a limit still holds, name the version it holds for
+rather than saying "cannot".
+
 ## First run — check auth before the first infra action
 
 Infra tasks (pods, endpoints, jobs, volumes) need a working control plane — the **Runpod MCP**

--- a/plugins/runpod/skills/runpod/SKILL.md
+++ b/plugins/runpod/skills/runpod/SKILL.md
@@ -4,8 +4,10 @@ description: >-
   Start here for any Runpod task — running GPU/CPU pods, deploying serverless
   endpoints, templates, network volumes, building images, or understanding how
   Runpod works. Routes the request to the right Runpod skill (runpod-mcp,
-  runpodctl, flash, companion-clis, or runpod-usage). Use when it is unclear
-  which Runpod skill applies.
+  runpodctl, flash, companion-clis, or runpod-usage) and indexes 25 verified
+  end-to-end worked examples (golden paths) to follow instead of re-deriving a
+  multi-step task. Use when it is unclear which Runpod skill applies, and for any
+  multi-step or provisioning task even when the lane is obvious.
 metadata:
   author: runpod
   version: "1.2.0" # x-release-please-version
@@ -15,7 +17,9 @@ license: Apache-2.0
 # Runpod (router)
 
 The entrypoint for the Runpod skills. This skill does no work itself — it picks
-the right lane and hands off. Read the matching skill's `SKILL.md` next.
+the right lane and hands off. For a multi-step or provisioning task, check the
+[worked examples](#worked-examples-golden-paths) first and let the matching one pick
+the lane; otherwise read the matching skill's `SKILL.md` next.
 
 ## The lanes
 
@@ -78,6 +82,24 @@ before any CLI-only step. Missing a CLI? `curl -sSL https://cli.runpod.net | bas
 [`runpod-usage/reference/getting-started.md`](../runpod-usage/reference/getting-started.md).
 
 ## How to route
+
+**0. Does a worked example already cover this?** For anything beyond a single call,
+check [the golden-paths index](#worked-examples-golden-paths) *before* picking a lane —
+a matching path already names the lane(s), the flags, the ordering, and the traps, so
+routing becomes reading rather than re-deriving. Check it when **any** of these is true:
+
+- the task needs **more than one resource** (image + template + endpoint, pod + volume,
+  multi-region, …) or **more than one lane**
+- it **provisions something billable**, or the user's ask is shaped like *"get X running /
+  deployed / working"*
+- it involves **storage, networking, autoscaling, streaming, or debugging a live resource** —
+  the areas where the non-obvious ordering is the whole difficulty
+- you are about to write a **multi-step plan** for it
+
+Skip step 0 for a single read or a single CRUD call ("list my pods", "stop pod X",
+"what GPUs are available") — go straight to the lane. **A matching golden path outranks
+this router's lane table**: it was verified end to end on a real account, so where the two
+disagree, follow the path and treat the difference as a bug worth reporting.
 
 1. **Conceptual question, or an unmade design choice** (serverless vs pod? which
    GPU? bake the model or mount a volume?) → read **runpod-usage** first, then
@@ -146,10 +168,16 @@ It branches to two sub-loops:
 
 ## Worked examples (golden paths)
 
-**Two dozen** end-to-end scenarios (nearly all **live-verified**) live in
-[`./golden-paths/README.md`](./golden-paths/README.md) — the yardstick for "can
-an agent finish the job", with real commands + observed output to copy from. When a
-task matches one, **open its golden path first** instead of re-deriving it:
+This is **step 0 of routing**, not an appendix. Two dozen end-to-end scenarios
+(nearly all **live-verified on a real account**) live in
+[`./golden-paths/README.md`](./golden-paths/README.md), with the real commands and the
+observed output to copy from — plus a Gotchas and a Cost & cleanup section each, which
+is the part that is expensive to rediscover.
+
+**Match the task to a row below and open that path before you plan or call anything.**
+A partial match is still worth opening: the closest path's ordering and gotchas usually
+transfer even when the model, GPU, or region does not. Only fall through to the lane
+tables above when nothing here is close.
 
 | Want to… | Golden path |
 | --- | --- |
@@ -163,6 +191,7 @@ task matches one, **open its golden path first** instead of re-deriving it:
 | **Custom serverless when flash isn't enough** (dual-mode image dev loop) | [09](./golden-paths/09-custom-serverless-dev-loop/README.md) |
 | Build a minimal image for a target (pod vs serverless queue) | [22 (pod)](./golden-paths/22-minimal-pod-image/README.md), [23 (queue)](./golden-paths/23-minimal-queue-image/README.md); concepts in [building-images](../runpod-usage/reference/building-images.md) |
 | Decide what to bake into the image vs mount on a network volume | [25 — bake vs mount](./golden-paths/25-bake-vs-mount/README.md) |
+| Pick a network-volume **storage tier** (standard vs high-performance) | [21 — storage tiers](./golden-paths/21-storage-tiers.md) |
 | **High availability / multi-region** serverless (multi-volume + data sync) | [10](./golden-paths/10-multi-region-ha-serverless.md), [19 (3-region)](./golden-paths/19-three-region-same-file.md) |
 | Stream output incrementally (`/stream`) | [12](./golden-paths/12-serverless-streaming.md) |
 | Tune autoscaling / raise per-worker throughput | [13 (autoscaling)](./golden-paths/13-autoscaling-tuning.md), [18 (concurrency)](./golden-paths/18-concurrent-handler.md) |

--- a/plugins/runpod/skills/runpod/evals/consult-golden-path-first.eval.md
+++ b/plugins/runpod/skills/runpod/evals/consult-golden-path-first.eval.md
@@ -1,0 +1,40 @@
+# Routing: check the worked example before planning a multi-step job
+
+## Prompt
+
+Two requests, answer both:
+
+(a) Stop pod `abc123`.
+(b) I want to serve a HuggingFace model on a serverless endpoint without baking the
+weights into the image or managing a network volume. Get me there.
+
+## Expected behavior
+
+The two halves must route **differently** — that split is the point of this eval.
+
+**(a) is a single CRUD call → skip step 0.** Goes straight to the lane per the
+capability matrix (`stop-pod` if MCP is connected, else `runpodctl pod stop abc123`).
+Opening a golden path for this is wrong: it burns a file read on a one-liner.
+
+**(b) is multi-resource and provisions something billable → step 0 applies.** Before
+planning or calling anything, matches the task against the golden-paths index in
+`runpod/SKILL.md` and finds the row *"Serve a HuggingFace model without baking it in or
+a volume (host-cached)"* → opens
+[golden path 20](../golden-paths/20-model-caching-endpoint.md) and follows it, including
+its `--model-reference` syntax, its GPU-only constraint, and its cost/cleanup section.
+It does **not** re-derive a plan from the lane tables, and does not go straight to
+`create-endpoint`/`serverless create` and improvise the model wiring.
+
+A partial match would still count: if the task were a model the path does not use, the
+path's ordering and gotchas still transfer, and opening it is correct.
+
+## Assertions
+
+- **(a)** answers with a single call and does **not** open a golden path
+- **(b)** consults the golden-paths index **before** proposing commands or a plan
+- **(b)** identifies path 20 (model caching / `--model-reference`) specifically, not
+  just "there are examples"
+- **(b)** does not present a hand-derived multi-step plan as the primary answer when a
+  verified path covers it
+- Neither half claims a capability is missing without checking (see
+  `no-unchecked-absence-claims.eval.md`)

--- a/plugins/runpod/skills/runpod/evals/consult-golden-path-first.eval.md
+++ b/plugins/runpod/skills/runpod/evals/consult-golden-path-first.eval.md
@@ -38,3 +38,59 @@ path's ordering and gotchas still transfer, and opening it is correct.
   verified path covers it
 - Neither half claims a capability is missing without checking (see
   `no-unchecked-absence-claims.eval.md`)
+
+---
+
+## Scenario B — entering a lane directly (the discriminating case)
+
+Scenario A above is a **weak test**, established by measurement: run against the router,
+agents opened the matching path with or without the step-0 rule, because the router's
+"Want to…" table has a near-verbatim row and agents read the file end to end. Keep A for
+the skip-on-trivial-call half, but A alone does not detect a regression.
+
+The case that separates them is an agent that **never reads the router** — it is already
+in a lane, which is the normal case once a session is underway.
+
+### Prompt
+
+*(session where the Runpod MCP tools are connected; entrypoint is
+`runpod-mcp/SKILL.md`, not the router)*
+
+I need a highly-available serverless endpoint. Same model weights available in three
+different data centers so a regional outage doesn't take me down. Walk me through it.
+
+### Expected behavior
+
+1. **Opens `runpod/golden-paths/README.md` before planning**, on the strength of the
+   lane's own "for a multi-step job, read the worked example before calling tools"
+   pointer — not because the user said "check the examples".
+2. **Lands on path 19** (3-region) or path 10 (2-region HA).
+3. **One endpoint, one volume per DC** — `--network-volume-ids v1,v2,v3` with
+   `--data-center-ids`. Not three separate endpoints behind a hand-rolled failover
+   layer, and not "bake the weights, volumes can't do this".
+4. **Flags that volumes do not replicate automatically** — a partial sync means a
+   fraction of traffic silently serves stale weights.
+5. Notes that MCP's `create-endpoint` does not express a multi-volume attach, so this
+   step needs runpodctl or the GraphQL `saveEndpoint` fallback.
+
+### Assertions
+
+- Opens a golden path **before** settling on an approach
+- Plan attaches several per-DC volumes to **one** endpoint
+- Warns about non-replication
+- Does **not** assert that a multi-DC endpoint cannot mount per-DC volumes — that is a
+  false absence claim, and it is the observed failure mode when the example is not read
+
+### Measured 2026-08-19
+
+Same prompt, 2 runs per arm, `origin/main` vs this branch, agents reporting the files
+they opened:
+
+| | opened a golden path | plan source | one endpoint + per-DC volumes |
+| --- | --- | --- | --- |
+| without the lane pointer | 0 / 2 | derived | 0 / 2 |
+| with it | 2 / 2, before planning | golden-path | 2 / 2 |
+
+Both control runs invented a limitation to justify the derived plan — *"you cannot
+attach one network volume to a multi-DC endpoint"* and *"network volumes are not a
+mechanism for multi-DC redundancy"* — both falsified by path 10's live 2026-07-10 run.

--- a/plugins/runpod/skills/runpod/evals/no-unchecked-absence-claims.eval.md
+++ b/plugins/runpod/skills/runpod/evals/no-unchecked-absence-claims.eval.md
@@ -1,0 +1,39 @@
+# Never assert a tool cannot do something without checking
+
+## Prompt
+
+I'm on runpodctl and I don't have the Runpod MCP connected. Can I read the logs of
+the workers behind my serverless endpoint from the CLI, or do I need the MCP server
+or the Console for that?
+
+## Expected behavior
+
+Per `runpod/SKILL.md` → *"These skills are a snapshot; the tools are the source of
+truth"*:
+
+1. **Answers yes, and names the command** — `runpodctl serverless logs <endpoint-id>`
+   (v2.10.0+), optionally narrowed with `--worker`. Reaching for
+   `runpodctl serverless --help` or `runpodctl version` to confirm the local binary
+   has it is *better*, not worse.
+2. **Does not answer from a remembered limitation.** "The CLI has no worker-log
+   command, use MCP or the Console" was true through v2.9.0 and is the exact answer
+   this eval exists to catch. A model that has internalized the older docs — or an
+   older copy of this skill — will produce it confidently.
+3. **If it hedges on version, it hedges with a floor, not a denial** — "needs
+   runpodctl ≥ v2.10.0; check `runpodctl version`" is correct. "runpodctl cannot do
+   this" is not.
+4. **Names the pre-v2.10.0 fallbacks as fallbacks**, if it mentions them at all: the
+   v2 REST SSE path, MCP `stream-worker-logs`, or the Console Workers tab.
+
+The same rule generalizes: the only capability claim this plugin should make in the
+negative is one carrying a version, a named API, or a "check it yourself" pointer.
+
+## Assertions
+
+- Answers **yes** and names `runpodctl serverless logs`
+- Does **not** claim runpodctl lacks a worker-log command
+- Does **not** require MCP or the Console to be the answer
+- Any version caveat is expressed as a floor (`≥ v2.10.0` / `runpodctl version`), not
+  as an absence
+- Bonus, not required: verifies against `runpodctl serverless --help` rather than
+  asserting from the skill text alone

--- a/plugins/runpod/skills/runpod/evals/route-serverless-observability.eval.md
+++ b/plugins/runpod/skills/runpod/evals/route-serverless-observability.eval.md
@@ -9,7 +9,7 @@ why. Then tell me what changes if I *do* have the Runpod MCP connected.
 ## Expected behavior
 
 Follows golden path 15 (`runpod/golden-paths/15-monitor-and-debug.md`), which
-splits into three signals with different lanes:
+splits into three signals — all three now reachable from the CLI lane:
 
 1. **Worker/job counts → `runpodctl serverless health ep-abc123`** (v2.9.0+). Not a
    hand-built `curl` to `https://api.runpod.ai/v2/ep-abc123/health` — that is the
@@ -20,15 +20,19 @@ splits into three signals with different lanes:
    decide scaling-bound vs handler-bound, and takes `workerId` from it. Knows the
    command exits **1** with `{"code":"job_failed"}` on a terminal `FAILED` while the
    job payload is still on stdout — that is the job failing, not the CLI.
-3. **Worker logs → NOT runpodctl.** There is no serverless worker-log command in
-   the CLI. Shell-only, that means the v2 REST SSE path
-   (`GET https://v2-rest.runpod.io/v2/serverless/ep-abc123/workers/<workerId>/logs`,
-   time-bounded with `curl -m`) or the Console **Workers** tab.
+3. **Worker logs → `runpodctl serverless logs ep-abc123`** (v2.10.0+), narrowed with
+   `--worker <workerId>` from step 2. Output is json lines
+   (`{source,line,ts,workerId}`), so it pipes to `jq`. **Not** a hand-built SSE read
+   against `v2-rest.runpod.io/.../logs` and not "the CLI can't do this" — that path is
+   the fallback for a pre-v2.10.0 binary, alongside the Console **Workers** tab.
+   Reads `--source container` for the handler's traceback, and knows `--source system`
+   with repeated "start container" and no container output means a crash loop.
 
-With MCP connected: `endpoint-health` and `get-job-status` become reasonable
-substitutes for steps 1–2, and step 3 gets a real upgrade — `list-endpoint-workers`
-→ `stream-worker-logs` returns already-parsed frames instead of raw SSE. The MCP
-lane is the *only* one of the two tool lanes that can read worker logs.
+With MCP connected: `endpoint-health` and `get-job-status` are reasonable substitutes
+for steps 1–2, and `list-endpoint-workers` → `stream-worker-logs` for step 3 returns
+already-parsed, bounded frames — a convenience over the CLI's json lines, **not** a
+capability the CLI lacks. Only `stream-job` (incremental job output) is genuinely
+MCP-only.
 
 ## Assertions
 
@@ -37,8 +41,10 @@ lane is the *only* one of the two tool lanes that can read worker logs.
 - Does **not** claim runpodctl is limited to create/list/delete — it also invokes
   (`serverless run`), polls (`serverless status`), reports health, and edits config
   (`serverless update`).
-- Correctly identifies worker logs as the one signal with no runpodctl command, and
-  names the v2 REST SSE path / MCP `stream-worker-logs` / Console instead.
-- Time-bounds any SSE read (`curl -m`), rather than tailing an open stream.
+- Reaches `runpodctl serverless logs` for the worker logs. Does **not** assert that
+  runpodctl cannot read worker logs, and does **not** require MCP to be connected to
+  get them.
+- If it falls back to the raw v2 REST SSE path (older binary), time-bounds the read
+  (`curl -m`) rather than tailing an open stream.
 - Treats a non-zero exit with `job_failed` as the worker's failure, not a CLI or
   auth problem.

--- a/plugins/runpod/skills/runpod/evals/route-serverless-observability.eval.md
+++ b/plugins/runpod/skills/runpod/evals/route-serverless-observability.eval.md
@@ -1,0 +1,44 @@
+# Routing: diagnosing a failing serverless job (health / status / worker logs)
+
+## Prompt
+
+I'm in a plain terminal — no MCP tools connected. My serverless endpoint
+`ep-abc123` just returned a `FAILED` job (`job-xyz`). Walk me through finding out
+why. Then tell me what changes if I *do* have the Runpod MCP connected.
+
+## Expected behavior
+
+Follows golden path 15 (`runpod/golden-paths/15-monitor-and-debug.md`), which
+splits into three signals with different lanes:
+
+1. **Worker/job counts → `runpodctl serverless health ep-abc123`** (v2.9.0+). Not a
+   hand-built `curl` to `https://api.runpod.ai/v2/ep-abc123/health` — that is the
+   fallback for an older binary or a copy-paste snippet, and the CLI returns the
+   same payload verbatim.
+2. **The job itself → `runpodctl serverless status ep-abc123 job-xyz`**. Reads
+   `status`, `error`, `retries`, and the `delayTime` vs `executionTime` split to
+   decide scaling-bound vs handler-bound, and takes `workerId` from it. Knows the
+   command exits **1** with `{"code":"job_failed"}` on a terminal `FAILED` while the
+   job payload is still on stdout — that is the job failing, not the CLI.
+3. **Worker logs → NOT runpodctl.** There is no serverless worker-log command in
+   the CLI. Shell-only, that means the v2 REST SSE path
+   (`GET https://v2-rest.runpod.io/v2/serverless/ep-abc123/workers/<workerId>/logs`,
+   time-bounded with `curl -m`) or the Console **Workers** tab.
+
+With MCP connected: `endpoint-health` and `get-job-status` become reasonable
+substitutes for steps 1–2, and step 3 gets a real upgrade — `list-endpoint-workers`
+→ `stream-worker-logs` returns already-parsed frames instead of raw SSE. The MCP
+lane is the *only* one of the two tool lanes that can read worker logs.
+
+## Assertions
+
+- Uses `runpodctl serverless health` and `runpodctl serverless status` rather than
+  steering to raw `curl` for `/health` and `/status`.
+- Does **not** claim runpodctl is limited to create/list/delete — it also invokes
+  (`serverless run`), polls (`serverless status`), reports health, and edits config
+  (`serverless update`).
+- Correctly identifies worker logs as the one signal with no runpodctl command, and
+  names the v2 REST SSE path / MCP `stream-worker-logs` / Console instead.
+- Time-bounds any SSE read (`curl -m`), rather than tailing an open stream.
+- Treats a non-zero exit with `job_failed` as the worker's failure, not a CLI or
+  auth problem.

--- a/plugins/runpod/skills/runpod/golden-paths/03-whisper-endpoint/README.md
+++ b/plugins/runpod/skills/runpod/golden-paths/03-whisper-endpoint/README.md
@@ -89,8 +89,11 @@ works).
 - **Broken Hub worker: `ready` but jobs never run.** A worker showing `ready` while
   jobs sit `IN_QUEUE` with `inProgress: 0` is a broken/mis-dispatching image (or
   workers `throttled` on a scarce GPU pool). **Switch workers, don't wait it out.**
-  There's no first-class serverless worker-log command in runpodctl/REST v1 —
-  diagnose via the endpoint `/health` worker counts. (Details in Variant A.)
+  Diagnose via the endpoint `/health` worker counts — `runpodctl serverless health <id>`
+  reads them for you (v2.9.0+). For the worker's own logs you need the MCP
+  `stream-worker-logs` tool, the v2 REST logs path, or the Console Workers tab:
+  there's no serverless worker-log command in runpodctl and no worker-log path on
+  REST v1. (Details in Variant A.)
 - **Delete returns 204, not JSON.** A DELETE / MCP `delete-*` may report an error
   like "Unexpected end of JSON input" because the REST API returns **204 No
   Content** (no body to parse). Treat it as success; confirm with a follow-up

--- a/plugins/runpod/skills/runpod/golden-paths/03-whisper-endpoint/variant-a-hub.md
+++ b/plugins/runpod/skills/runpod/golden-paths/03-whisper-endpoint/variant-a-hub.md
@@ -99,11 +99,13 @@ curl -s https://api.runpod.ai/v2/<endpoint-id>/status/<job-id> \
 
 - **Not all Hub workers work.** A `ready` worker with jobs stuck `IN_QUEUE` /
   `inProgress: 0` is a broken image — switch, don't wait (see the picking lesson).
-- **No first-class serverless worker-log access** from runpodctl / REST v1 / GraphQL
-  introspection (all dead ends on this run). Diagnosis relied on the endpoint
-  `/health` worker counts. A `runpodctl serverless logs <endpoint-id>` would have
-  made the broken-worker call much faster. (The MCP server does expose
-  `stream-pod-logs`/worker log streaming if it's connected.)
+- **Worker logs were the missing signal on this run** — at the time runpodctl had no
+  worker-log command, REST v1 has no worker-log path, and GraphQL introspection was a
+  dead end, so diagnosis relied on the endpoint `/health` worker counts alone.
+  **Fixed upstream:** `runpodctl serverless logs <endpoint-id>` shipped in v2.10.0 and
+  is now the fast way to make the broken-worker call — `--source system` showing
+  repeated `start container` with no `container` output is the crash-loop tell this run
+  had to infer. (MCP `stream-worker-logs` does the same when it's connected.)
 - **`serverless update` has no `--gpu-id` flag.** To change an existing endpoint's
   GPU pool you must `PATCH https://rest.runpod.io/v1/endpoints/<id>` with
   `{"gpuTypeIds":[...]}`. (To *override* the pool at create time, pass `--gpu-id` on

--- a/plugins/runpod/skills/runpod/golden-paths/07-network-volume-handoff.md
+++ b/plugins/runpod/skills/runpod/golden-paths/07-network-volume-handoff.md
@@ -128,8 +128,9 @@ loaded — and the real errors:
 
 **Fix:** handler takes `**kwargs` (or params matching the input keys) **and** invoke with a
 non-empty `input`. Lesson: with no worker-log visibility a job-reject is indistinguishable
-from a broken worker — get the logs (MCP `stream-worker-logs`) before assuming the worker is
-bad.
+from a broken worker — get the logs before assuming the worker is bad. This run used MCP
+`stream-worker-logs`, which was the only option at the time; since runpodctl v2.10.0
+`runpodctl serverless logs <id> --source container` reads the same stream from a shell.
 
 ## Cost & cleanup
 ```bash

--- a/plugins/runpod/skills/runpod/golden-paths/08-finetune-to-serverless.md
+++ b/plugins/runpod/skills/runpod/golden-paths/08-finetune-to-serverless.md
@@ -224,6 +224,7 @@ scale-to-zero (`workers=(0,1)`), ~$0 idle. Keep the volume only while iterating.
   `input` (flash SKILL gotcha "Request body shape").
 - **Load the model once** in the class `__init__`, not per request (flash SKILL gotcha).
 - **PEP 668** on the training pod: `pip install --break-system-packages …` (`on-pod-setup.md`).
-- **Diagnosis:** if the endpoint job times out, pull worker logs with the MCP
-  `stream-worker-logs` before assuming a broken worker — it's usually a payload/handler issue.
+- **Diagnosis:** if the endpoint job times out, pull worker logs before assuming a broken
+  worker — it's usually a payload/handler issue. `runpodctl serverless logs <id> --source
+  container` (v2.10.0+) or MCP `stream-worker-logs`.
 - **Same DC** for volume + pod + endpoint (the volume is DC-pinned).

--- a/plugins/runpod/skills/runpod/golden-paths/14-load-balancing-endpoint.md
+++ b/plugins/runpod/skills/runpod/golden-paths/14-load-balancing-endpoint.md
@@ -263,8 +263,8 @@ Kept image: `<your-registry>/gp14-lb:v1` (the tiny stdlib LB worker above).
 
 ## Skill gaps folded back
 - The load-balancing endpoint type is settable headlessly two ways: **v2 REST**
-  (`"type": "LOAD_BALANCER"`) or **GraphQL `saveEndpoint`** (`type: "LB"`). **v1** REST
-  endpoint-create and `runpodctl serverless create` have no type field, and no API can change
+  (`"type": "LOAD_BALANCER"`) or **GraphQL `saveEndpoint`** (`type: "LB"`). The **v1** REST
+  endpoint-create call and `runpodctl serverless create` have no type field, and no API can change
   the type after creation. Skills that create endpoints should note this when a custom-HTTP/LB
   endpoint is wanted.
 - **Setting `PORT_HEALTH` (and exposing the port) explicitly is effectively required**, not

--- a/plugins/runpod/skills/runpod/golden-paths/15-monitor-and-debug.md
+++ b/plugins/runpod/skills/runpod/golden-paths/15-monitor-and-debug.md
@@ -2,10 +2,13 @@
 
 **Goal:** the observability toolkit for a running serverless endpoint — answer "are my
 workers healthy?", "why is this job stuck?", and "what did the worker actually do?" using
-`/health` worker+job counts, the job `/status` lifecycle, and worker log streaming. This is
+`/health` worker+job counts, the job `/status` lifecycle, and worker logs. This is
 the loop you run when a request is slow, stuck `IN_QUEUE`, or `FAILED`.
 **Status:** ✅ **COVERED — live-verified 2026-07-13, re-verified against runpodctl v2.9.0 on
-2026-08-06.** The 2026-07-13 pass deployed a tiny CPU scale-to-zero echo endpoint
+2026-08-06. Command surface re-checked against runpodctl v2.10.0 on 2026-08-19** (the
+`serverless logs` / `pod logs` route below is verified from the shipped v2.10.0 binary's
+interface, not from a live log capture — the captured frames are still the 2026-08-06 SSE run
+against the identical upstream service). The 2026-07-13 pass deployed a tiny CPU scale-to-zero echo endpoint
 (`python:3.11-slim` + `runpod`), sent one async job, and captured `/health` moving **idle →
 ready → throttled → ready** while a job moved **`IN_QUEUE` → `IN_PROGRESS` → `COMPLETED`**, the
 completed `/status` carrying `delayTime`/`executionTime`/`workerId`, the **v2 REST worker-log
@@ -14,10 +17,11 @@ SSE stream** returning `system` and `container` frames, and config toggles appli
 health`/`status`/`run` against a live GPU endpoint and captured the **failure** branch end to
 end: one job walked `IN_QUEUE` → `IN_PROGRESS` → **`FAILED`** with a server-side retry, and the
 worker `container` log named the real cause the `/status` `error` string hid.
-**Lane(s):** runpodctl (`serverless health` / `run` / `status` / `update`, v2.9.0+) +
-REST/HTTP (`/health`, `/status`, v1 `PATCH`) + v2 REST worker logs
-(`GET /v2/serverless/{id}/workers/{workerId}/logs`, SSE) + Runpod MCP (`stream-worker-logs`,
-`list-endpoint-workers`, `endpoint-health`) + Console (Logs/Workers/Metrics tabs)
+**Lane(s):** runpodctl (`serverless health` / `run` / `status` / `update`, v2.9.0+;
+`serverless logs` / `pod logs`, v2.10.0+) + REST/HTTP (`/health`, `/status`, v1 `PATCH`) +
+v2 REST worker logs (`GET /v2/serverless/{id}/workers/{workerId}/logs`, SSE) + Runpod MCP
+(`stream-worker-logs`, `list-endpoint-workers`, `endpoint-health`) + Console
+(Logs/Workers/Metrics tabs)
 
 ## When to use this
 Reach for this path whenever a deployed endpoint isn't behaving:
@@ -37,18 +41,18 @@ endpoint up; this one tells you whether it's healthy and why a job did what it d
 | --- | --- | --- | --- |
 | Are workers healthy / how many? | worker state counts | `runpodctl serverless health <id>` · MCP `endpoint-health` | `GET api.runpod.ai/v2/<id>/health` |
 | Where is *this* job? | job state + timings | `runpodctl serverless status <id> <job-id>` · MCP `get-job-status` | `GET api.runpod.ai/v2/<id>/status/<job-id>` |
-| What did the worker *do*? | container/system logs | MCP `stream-worker-logs` | `GET v2-rest.runpod.io/v2/serverless/<id>/workers/<worker-id>/logs` (SSE) · Console Workers tab |
+| What did the worker *do*? | container/system logs | `runpodctl serverless logs <id>` · MCP `stream-worker-logs` | `GET v2-rest.runpod.io/v2/serverless/<id>/workers/<worker-id>/logs` (SSE) · Console Workers tab |
 | Did my config change take? | endpoint config | `runpodctl serverless update <id> …` then `serverless get <id>` | v1 `PATCH`/`GET rest.runpod.io/v1/endpoints/<id>` |
 
-All four signals are free to read. The `runpodctl` commands are v2.9.0+; the raw HTTP column is
-what you hand a user for copy-paste, what a non-Runpod client speaks, and what you fall back to
-on an older binary.
+All four signals are free to read. The raw HTTP column is what you hand a user for copy-paste,
+what a non-Runpod client speaks, and what you fall back to on an older binary.
 
-`runpodctl` reads health and job status, invokes jobs, and edits endpoint config — but it has
-**no serverless worker-log command** (verified against the v2.9.0 binary: `runpodctl serverless`
-exposes `create`, `delete`, `get`, `health`, `list`, `run`, `status`, `update`, and nothing
-else). For worker logs use the v2 REST logs path, the Runpod MCP `stream-worker-logs` tool, or
-the Console **Workers** tab.
+**All four are first-class `runpodctl` commands as of v2.10.0** — `serverless health`,
+`serverless status`, `serverless update` (v2.9.0+) and `serverless logs` (v2.10.0+). The
+v2.10.0 `serverless` surface is `create`, `delete`, `get`, `health`, `list`, `logs`, `run`,
+`status`, `update`. Mind the version floor: on a **v2.9.0** binary there is no `logs`
+subcommand, and the worker-log signal has to come from the v2 REST SSE path, the Runpod MCP
+`stream-worker-logs` tool, or the Console **Workers** tab. Check `runpodctl version` first.
 
 ## Prerequisites
 - `RUNPOD_API_KEY` resolvable (the same key authorizes `api.runpod.ai/v2`, `rest.runpod.io/v1`,
@@ -182,11 +186,50 @@ a lengthening queue.
 ## 3. Worker logs — what the worker actually did
 
 Endpoint (aggregate, 90-day retained) logs and per-worker (ephemeral, on-host) logs are both
-in the Console (**Logs** and **Workers** tabs). For programmatic/agent access there are two
-routes; `runpodctl` has no worker-log command, so this is the one signal the CLI lane cannot
-give you.
+in the Console (**Logs** and **Workers** tabs). For programmatic/agent access there are three
+routes, in preference order: the CLI (v2.10.0+), the MCP tool, or the raw v2 REST stream.
 
-### Route A — v2 REST logs (SSE)
+### Route A — `runpodctl serverless logs` (v2.10.0+, prefer this)
+```bash
+# every worker's recent logs, json lines — one {source,line,ts,workerId} per line
+runpodctl serverless logs <endpoint-id>
+
+# narrow to the worker that served the failed job (workerId comes from /status)
+runpodctl serverless logs <endpoint-id> --worker <worker-id> --source container
+
+# why a worker will not start, last hour of platform lines
+runpodctl serverless logs <endpoint-id> --since 1h --source system
+
+# live tail; picks up workers that scale up while it runs
+runpodctl serverless logs <endpoint-id> --follow
+```
+Logs belong to a **worker**, not the endpoint, so without `--worker` this resolves the
+endpoint's workers and reads them all at once, tagging each line with its `workerId` — which is
+what you want when you don't yet know which worker misbehaved. Flags: `--source
+container|system|both` (default `both`), `--tail 0-5000` (default 100, `0` = live only),
+`--since 30m|2h|7d|<rfc3339>` (overrides `--tail`), `--worker`, `--follow`, and `--max-wait`
+(default `5s`, how long to wait for output before exiting when *not* following).
+
+Two things this buys over the raw stream: it is **json lines, not SSE**, so `| jq` works with no
+frame parsing, and without `--follow` it **terminates on its own** once the replayed lines stop
+arriving instead of hanging on an open connection. With `--follow` it reconnects itself if the
+connection drops.
+
+```bash
+# the handler's own error lines for one worker
+runpodctl serverless logs <endpoint-id> --worker <worker-id> --source container \
+  | jq -r 'select(.line | contains("ERROR")) | "\(.ts) \(.line)"'
+```
+
+> **Crash-loop tell:** repeated `system` `start container` lines with **no** `container` output
+> means the container exits before the handler runs. Jobs then pile up `IN_QUEUE` even though
+> `/health` shows workers — nothing is wrong with capacity, the image is wrong.
+
+Same story for pods: `runpodctl pod logs <pod-id>` (identical flags minus `--worker`) is the
+first thing to run on a pod that never becomes usable, and `--source system` is where a stalled
+image pull or a `create container` that never reaches `start` shows up.
+
+### Route B — v2 REST logs (SSE, or a pre-v2.10.0 binary)
 ```bash
 # workerId comes from /status.workerId or the workers list below
 curl -sN -m 20 "https://v2-rest.runpod.io/v2/serverless/<endpoint-id>/workers/<worker-id>/logs?source=container&tail=100" \
@@ -245,15 +288,17 @@ v1 control plane and returns the raw worker records — far more fields, includi
 `RUNPOD_AI_API_KEY`/`RUNPOD_ENDPOINT_SECRET` in `env`. Prefer the v2 list (or the MCP tool)
 when you just need ids and states, and don't paste `--include-workers` output into a ticket.
 
-### Route B — Runpod MCP `stream-worker-logs`
+### Route C — Runpod MCP `stream-worker-logs`
 The hosted Runpod MCP (`https://mcp.getrunpod.io/`) wraps the exact same endpoint as a tool:
 `list-endpoint-workers` → pick a `workerId` → `stream-worker-logs` (params `source`, `tail`,
 `since`, `maxWaitMs`). It returns a bounded, already-parsed snapshot — `{"items":[{"source",
-"line","ts"}…],"count","truncated"}` — which is the easiest route from inside an agent (✅ used
-live 2026-08-06). This is the same tool golden path
+"line","ts"}…],"count","truncated"}` — a convenient shape inside an agent (✅ used live
+2026-08-06). This is the same tool golden path
 [07](07-network-volume-handoff.md) used to distinguish a healthy worker from a bad payload.
+Since v2.10.0 it is a **convenience over Route A, not a capability the CLI lacks**; pick it when
+MCP is already connected and you want parsed frames without shelling out.
 
-> Both routes live on the **v2 serverless REST service** (`v2-rest.runpod.io/v2`), not on
+> Routes B and C live on the **v2 serverless REST service** (`v2-rest.runpod.io/v2`), not on
 > `rest.runpod.io/v1` — v1 has no worker-log path at all. That is a statement about which
 > service you call, *not* about the endpoint's own `version` field: ✅ verified live that a
 > `version: 1` endpoint's workers and logs are readable through the v2 route (HTTP 200, real
@@ -298,17 +343,18 @@ can schedule. Re-read `/health` right after a change to confirm workers redistri
 2. **`runpodctl serverless status <id> <job-id>`** — where is the job? Split `delayTime`
    (queue/scaling) vs. `executionTime` (handler). Grab `workerId`. Exit code 1 + `job_failed`
    means the job itself failed, not the call.
-3. **Worker `container` logs** (MCP `stream-worker-logs` or the v2 REST SSE path) for that
-   `workerId` — read the fitness checks and the per-`requestId` lines. A `FAILED` job's real
-   cause is here, and it is often *not* what `/status.error` says.
+3. **`runpodctl serverless logs <id> --worker <workerId> --source container`** (v2.10.0+; MCP
+   `stream-worker-logs` or the v2 REST SSE path on an older binary) — read the fitness checks
+   and the per-`requestId` lines. A `FAILED` job's real cause is here, and it is often *not*
+   what `/status.error` says.
 4. **Config** — if capacity/region is the constraint, `runpodctl serverless update
    --workers-max` (or `PATCH` `dataCenterIds`) and re-check health.
 
 ## Gotchas
-- **No `runpodctl` serverless worker-log command** — worker logs come from the v2 REST logs
-  path, the Runpod MCP `stream-worker-logs`, or the Console Workers tab. Everything *else* in
-  this path has a v2.9.0 CLI command: `serverless health`, `serverless status`, `serverless run`,
-  `serverless update`.
+- **`serverless logs` needs runpodctl ≥ v2.10.0** — it does not exist on v2.9.0, where the
+  worker-log signal has to come from the v2 REST logs path, the Runpod MCP
+  `stream-worker-logs`, or the Console Workers tab. `runpodctl version` first; the Homebrew tap
+  can lag the GitHub release.
 - **`/status.error` can name the wrong culprit** — seen live: `"job timed out after 1 retries"`
   on a worker whose fitness checks all passed; the container log showed it was rejecting the
   request payload. Always read the worker log before blaming capacity or the image.
@@ -317,9 +363,11 @@ can schedule. Re-read `/health` right after a change to confirm workers redistri
   frames for that worker while `source=system` still returned its lifecycle history. Capture
   container logs *while the worker is up*. Aggregate **endpoint** logs (Console Logs tab) are
   retained 90 days; for permanent logs, write to a network volume or an external sink.
-- **Worker logs are SSE, not JSON** — parse `data:` frames and always time-bound the read
-  (`curl -m`), or it will hang tailing live output. A worker with nothing to say holds the
-  connection open and sends nothing, so an unbounded read simply never returns.
+- **The raw v2 logs path is SSE, not JSON** — on Route B parse `data:` frames and always
+  time-bound the read (`curl -m`), or it will hang tailing live output: a worker with nothing to
+  say holds the connection open and sends nothing, so an unbounded read never returns. Route A
+  (`serverless logs`) removes both hazards — json lines, and it exits on its own without
+  `--follow` (`--max-wait` bounds that).
 - **`throttled` is usually transient** — it means the host pool is momentarily constrained
   (seen live: workers flipped `throttled` then recovered on their own within ~30 s). A
   scale-to-zero endpoint can also show a lone `throttled` leftover record while genuinely idle.
@@ -348,10 +396,12 @@ handler that returns its input plus `RUNPOD_POD_ID`/`RUNPOD_DC_ID`) is left publ
 cites a real, pullable tag; it costs nothing.
 
 ## Skill facts confirmed / folded back
-- **Three of the four signals are first-class CLI commands as of v2.9.0** — `serverless health`
-  and `serverless status` hit the invoke service (`api.runpod.ai/v2`) and pass its JSON through
-  verbatim; `serverless update` `PATCH`es the v1 control plane. Worker logs remain the one
-  signal with no CLI command.
+- **All four signals are first-class CLI commands as of v2.10.0** — `serverless health` and
+  `serverless status` hit the invoke service (`api.runpod.ai/v2`) and pass its JSON through
+  verbatim; `serverless update` `PATCH`es the v1 control plane; `serverless logs` (v2.10.0)
+  closed the last gap, wrapping the v2 worker-log stream as json lines with its own worker
+  resolution and reconnect. Three of the four arrived in v2.9.0, so a doc pinned to that release
+  reads the log signal as MCP-only — it isn't.
 - **`/health` returns six worker-state fields** (`idle`, `initializing`, `ready`, `running`,
   `throttled`, `unhealthy`) — richer than the `{idle,running}` shape in the operation
   reference, and richer than the v2 worker-list `summary`, which has no `ready`.
@@ -363,8 +413,9 @@ cites a real, pullable tag; it costs nothing.
 - **Worker log streaming is a real, reachable v2 REST endpoint** —
   `GET https://v2-rest.runpod.io/v2/serverless/<id>/workers/<workerId>/logs` (SSE, params
   `source`/`tail`/`since`), and `.../workers` lists workers with status/GPU/DC. Both work for
-  `version: 1` endpoints too. The Runpod MCP (`list-endpoint-workers` + `stream-worker-logs`)
-  wraps both.
+  `version: 1` endpoints too. Both the Runpod MCP (`list-endpoint-workers` +
+  `stream-worker-logs`) and `runpodctl serverless logs` (v2.10.0+) wrap it — the CLI does the
+  worker resolution for you, so `--worker` is optional.
 - **`serverless get --include-workers` echoes endpoint secrets** — it returns raw v1 worker
   records including `RUNPOD_AI_API_KEY`/`RUNPOD_ENDPOINT_SECRET` in `env`. Use the v2 worker
   list when you only need ids and states.

--- a/plugins/runpod/skills/runpod/golden-paths/15-monitor-and-debug.md
+++ b/plugins/runpod/skills/runpod/golden-paths/15-monitor-and-debug.md
@@ -4,17 +4,20 @@
 workers healthy?", "why is this job stuck?", and "what did the worker actually do?" using
 `/health` worker+job counts, the job `/status` lifecycle, and worker log streaming. This is
 the loop you run when a request is slow, stuck `IN_QUEUE`, or `FAILED`.
-**Status:** ✅ **COVERED — live-verified 2026-07-13** end to end. Deployed a tiny CPU
-scale-to-zero echo endpoint (`python:3.11-slim` + `runpod`), sent one async job, and
-live-captured the full signal set: `/health` transitioning **idle → ready → throttled →
-ready** while a job moved **`IN_QUEUE` → `IN_PROGRESS` → `COMPLETED`**; the completed
-`/status` carrying `delayTime`/`executionTime`/`workerId`; the **v2 REST worker-log SSE
-stream** returning both `system` (image pull) and `container` (fitness checks + per-request
-`Started`/`Finished`) frames correlated by `requestId`; and config-change toggles
-(`workersMax`, data-center set) applied via v1 `PATCH` (HTTP 200 each).
-**Lane(s):** REST/HTTP (`/health`, `/status`, v1 `PATCH`) + v2 REST worker logs
+**Status:** ✅ **COVERED — live-verified 2026-07-13, re-verified against runpodctl v2.9.0 on
+2026-08-06.** The 2026-07-13 pass deployed a tiny CPU scale-to-zero echo endpoint
+(`python:3.11-slim` + `runpod`), sent one async job, and captured `/health` moving **idle →
+ready → throttled → ready** while a job moved **`IN_QUEUE` → `IN_PROGRESS` → `COMPLETED`**, the
+completed `/status` carrying `delayTime`/`executionTime`/`workerId`, the **v2 REST worker-log
+SSE stream** returning `system` and `container` frames, and config toggles applied via v1
+`PATCH` (HTTP 200 each). The 2026-08-06 pass re-ran the read path with `runpodctl serverless
+health`/`status`/`run` against a live GPU endpoint and captured the **failure** branch end to
+end: one job walked `IN_QUEUE` → `IN_PROGRESS` → **`FAILED`** with a server-side retry, and the
+worker `container` log named the real cause the `/status` `error` string hid.
+**Lane(s):** runpodctl (`serverless health` / `run` / `status` / `update`, v2.9.0+) +
+REST/HTTP (`/health`, `/status`, v1 `PATCH`) + v2 REST worker logs
 (`GET /v2/serverless/{id}/workers/{workerId}/logs`, SSE) + Runpod MCP (`stream-worker-logs`,
-`list-endpoint-workers`) + Console (Logs/Workers/Metrics tabs)
+`list-endpoint-workers`, `endpoint-health`) + Console (Logs/Workers/Metrics tabs)
 
 ## When to use this
 Reach for this path whenever a deployed endpoint isn't behaving:
@@ -30,38 +33,58 @@ endpoint up; this one tells you whether it's healthy and why a job did what it d
 
 ## The four signals (and where each comes from)
 
-| Question | Signal | Source | Cost |
+| Question | Signal | First choice | Zero-dependency fallback |
 | --- | --- | --- | --- |
-| Are workers healthy / how many? | worker state counts | `GET api.runpod.ai/v2/<id>/health` | free, instant |
-| Where is *this* job? | job state + timings | `GET api.runpod.ai/v2/<id>/status/<jobId>` | free, instant |
-| What did the worker *do*? | container/system logs | v2 REST worker logs · MCP `stream-worker-logs` · Console Workers tab | free |
-| Did my config change take? | endpoint config | v1 `PATCH`/`GET rest.runpod.io/v1/endpoints/<id>` | free |
+| Are workers healthy / how many? | worker state counts | `runpodctl serverless health <id>` · MCP `endpoint-health` | `GET api.runpod.ai/v2/<id>/health` |
+| Where is *this* job? | job state + timings | `runpodctl serverless status <id> <job-id>` · MCP `get-job-status` | `GET api.runpod.ai/v2/<id>/status/<job-id>` |
+| What did the worker *do*? | container/system logs | MCP `stream-worker-logs` | `GET v2-rest.runpod.io/v2/serverless/<id>/workers/<worker-id>/logs` (SSE) · Console Workers tab |
+| Did my config change take? | endpoint config | `runpodctl serverless update <id> …` then `serverless get <id>` | v1 `PATCH`/`GET rest.runpod.io/v1/endpoints/<id>` |
 
-There is **no first-class `runpodctl` command for serverless worker logs** — use the v2 REST
-logs path, the Runpod MCP `stream-worker-logs` tool, or the Console **Workers** tab.
+All four signals are free to read. The `runpodctl` commands are v2.9.0+; the raw HTTP column is
+what you hand a user for copy-paste, what a non-Runpod client speaks, and what you fall back to
+on an older binary.
+
+`runpodctl` reads health and job status, invokes jobs, and edits endpoint config — but it has
+**no serverless worker-log command** (verified against the v2.9.0 binary: `runpodctl serverless`
+exposes `create`, `delete`, `get`, `health`, `list`, `run`, `status`, `update`, and nothing
+else). For worker logs use the v2 REST logs path, the Runpod MCP `stream-worker-logs` tool, or
+the Console **Workers** tab.
 
 ## Prerequisites
 - `RUNPOD_API_KEY` resolvable (the same key authorizes `api.runpod.ai/v2`, `rest.runpod.io/v1`,
-  and `v2-rest.runpod.io/v2`).
+  and `v2-rest.runpod.io/v2`). `runpodctl` also reads the key saved by `runpodctl doctor`.
 - A deployed endpoint id. Below uses a tiny CPU echo endpoint (build any handler; see
   [05](05-model-to-endpoint-pipeline.md) for the two-step template→endpoint pattern).
 
 ## 1. `/health` — worker & job counts (start here)
 
 ```bash
+runpodctl serverless health <endpoint-id>            # v2.9.0+, pretty-prints; -o yaml also works
+# zero-dependency equivalent:
 curl -s https://api.runpod.ai/v2/<endpoint-id>/health -H "Authorization: Bearer $RUNPOD_API_KEY"
 ```
-✅ Live — a scale-to-zero endpoint idle, then holding a queued job, then after completion:
+The CLI passes the invoke API's response through verbatim, so the two agree field for field —
+✅ verified live 2026-08-06, run back to back against the same endpoint:
 ```jsonc
-// idle, just created (worker warming)
-{"jobs":{"completed":0,"failed":0,"inProgress":0,"inQueue":0,"retried":0},
- "workers":{"idle":0,"initializing":1,"ready":0,"running":0,"throttled":0,"unhealthy":0}}
-// a job queued, a worker ready
-{"jobs":{"completed":0,"failed":0,"inProgress":0,"inQueue":1,"retried":0},
- "workers":{"idle":1,"initializing":0,"ready":1,"running":0,"throttled":0,"unhealthy":0}}
-// after completion
-{"jobs":{"completed":1,"failed":0,"inProgress":0,"inQueue":0,"retried":0},
- "workers":{"idle":3,"initializing":0,"ready":3,"running":0,"throttled":0,"unhealthy":0}}
+// runpodctl serverless health <id>   (and curl, minus the indentation)
+{"jobs":{"completed":27,"failed":0,"inProgress":0,"inQueue":0,"retried":0},
+ "workers":{"idle":0,"initializing":0,"ready":0,"running":0,"throttled":1,"unhealthy":0}}
+```
+✅ Live — a second endpoint idle, then holding a queued job, then running it, then after it
+failed:
+```jsonc
+// idle, scale-to-zero
+{"jobs":{"completed":31,"failed":0,"inProgress":0,"inQueue":0,"retried":0},
+ "workers":{"idle":2,"initializing":0,"ready":2,"running":0,"throttled":0,"unhealthy":0}}
+// a job queued, a worker coming up
+{"jobs":{"completed":31,"failed":0,"inProgress":0,"inQueue":1,"retried":0},
+ "workers":{"idle":1,"initializing":1,"ready":1,"running":0,"throttled":0,"unhealthy":0}}
+// job picked up
+{"jobs":{"completed":31,"failed":0,"inProgress":1,"inQueue":0,"retried":0},
+ "workers":{"idle":0,"initializing":1,"ready":0,"running":1,"throttled":0,"unhealthy":0}}
+// after it failed (note failed + retried)
+{"jobs":{"completed":31,"failed":1,"inProgress":0,"inQueue":0,"retried":1},
+ "workers":{"idle":1,"initializing":0,"ready":1,"running":1,"throttled":0,"unhealthy":0}}
 ```
 
 **Worker states** (the live `/health` payload carries all six — richer than the two-field
@@ -76,115 +99,192 @@ curl -s https://api.runpod.ai/v2/<endpoint-id>/health -H "Authorization: Bearer 
 | `unhealthy` | crashed; auto-retried for up to 7 days | no |
 
 **`jobs` counters** aggregate the queue: `inQueue`, `inProgress`, `completed`, `failed`,
-`retried`. `SDK` equivalents exist (`endpoint.health()` in the Python/JS SDKs) but the raw
-`curl` above is the zero-dependency check.
+`retried`. SDK equivalents exist (`endpoint.health()` in the Python/JS SDKs).
 
 ### Reading it: healthy vs. stuck
 - **Healthy & scaled:** `ready`/`idle` ≥ 1 and `inQueue` draining. A request will be picked up.
 - **Stuck `IN_QUEUE`:** `inQueue` > 0 but `running`/`ready` = 0. Look at *why* no worker is
   free — the two common causes below.
-- **`throttled` > 0:** the host pool is momentarily constrained (verified live — see next
-  section). Workers usually recover on their own; a **persistently** throttled endpoint on a
-  scarce GPU means you pinned too narrow a pool — widen GPU types or data centers.
+- **`throttled` > 0:** the host pool is momentarily constrained (verified live). Workers usually
+  recover on their own; a **persistently** throttled endpoint on a scarce GPU means you pinned
+  too narrow a pool — widen GPU types or data centers.
 - **`unhealthy` > 0:** the worker crashed on start or mid-job — go straight to the logs.
+
+### `/health` counts and the worker list are two different views
+`/health` is the scheduler's rolled-up gauge; the v2 worker list (next section) enumerates the
+actual worker records. They can disagree, and neither is wrong — ✅ observed live 2026-08-06,
+the two calls made back to back against the same endpoint:
+```jsonc
+// GET /v2/<id>/health
+"workers":{"idle":1,"initializing":0,"ready":1,"running":1,"throttled":0,"unhealthy":0}
+// GET v2-rest.runpod.io/v2/serverless/<id>/workers  →  summary
+{"idle":1,"initializing":2,"running":0,"throttled":2,"total":5,"unhealthy":0}
+```
+Use `/health` for "can this endpoint take work right now"; use the worker list when you need a
+specific `workerId`, its data center, or its image. Note the worker-list `summary` has **no
+`ready` key** — `ready` exists only on `/health`.
 
 ## 2. Job `/status` — the request lifecycle
 
 ```bash
+# submit and get a job id back immediately (v2.9.0+)
+runpodctl serverless run <endpoint-id> --input '{"prompt":"hi"}' --no-wait
+# poll it — one check, or --wait to block until terminal
+runpodctl serverless status <endpoint-id> <job-id>
+runpodctl serverless status <endpoint-id> <job-id> --wait 5m
+# zero-dependency equivalent:
 curl -s https://api.runpod.ai/v2/<endpoint-id>/status/<job-id> -H "Authorization: Bearer $RUNPOD_API_KEY"
 ```
 Job states: `IN_QUEUE` → `IN_PROGRESS` (a.k.a. `RUNNING`) → `COMPLETED`, or `FAILED` /
-`CANCELLED` / `TIMED_OUT`. ✅ Live capture of one async job walking the whole path while
-`/health` moved in lockstep:
+`CANCELLED` / `TIMED_OUT`.
+
+✅ Live 2026-08-06 — one async job (deliberately empty `--input '{}'`) walking the whole path to
+a **real failure**, with `/health` in lockstep:
 ```
-[q]  status=IN_QUEUE     workers={ready:1, throttled:0}
-[q]  status=IN_QUEUE     workers={throttled:2}          # host briefly constrained
-[q]  status=IN_QUEUE     workers={ready:1, throttled:1} # recovering
-[r]  status=IN_PROGRESS  workers={idle:2, ready:2}
-[c]  status=COMPLETED    workers={idle:2, ready:2}
+17:42:13  IN_QUEUE                                     health workers={idle:1,initializing:1,ready:1}  jobs={inQueue:1}
+17:42:49  IN_QUEUE     worker z3jr9rv2k3tt2y → RUNNING
+17:43:02  IN_PROGRESS  delayTime=61372   workerId=z3jr9rv2k3tt2y                                        jobs={inProgress:1}
+17:43:48  IN_PROGRESS  delayTime=101050  retries=1     # server-side retry; delayTime was recomputed    jobs={retried:1}
+17:44:30  FAILED       delayTime=101050  executionTime=42078  retries=1                                 jobs={failed:1,retried:1}
 ```
-The completed `/status` carries the timing + routing fields you use to explain a slow request:
+The terminal payload, straight from `runpodctl serverless status`:
 ```jsonc
-{"id":"bb2a...-u1","status":"COMPLETED",
- "delayTime":58547,      // ms the job waited in queue (here: inflated by the throttle above)
- "executionTime":8177,   // ms the handler actually ran
- "workerId":"jfnozynhb29r3c",   // which worker served it — feed this to worker logs
- "output":{"echo":{"msg":"hello gp15"},"dc":"EU-RO-1","worker_id":"jfnozynhb29r3c"}}
+{"delayTime":101050,          // ms the job waited before its (final) attempt started
+ "error":"job timed out after 1 retries",
+ "executionTime":42078,       // ms the handler side actually held it
+ "id":"bd9227e3-…-u1",
+ "retries":1,                 // the platform re-dispatched it once
+ "status":"FAILED",
+ "workerId":"z3jr9rv2k3tt2y"} // which worker served it — feed this to worker logs
 ```
+On a terminal non-`COMPLETED` status the CLI still prints that payload on **stdout**, adds
+`{"error":"job … finished with status FAILED","code":"job_failed"}` on **stderr**, and exits
+**1** (observed). A `COMPLETED` job's payload additionally carries `output` with whatever the
+handler returned. `error` and `retries` only appear when the platform produced them.
+
 `delayTime` vs. `executionTime` is the key split: a big `delayTime` with a small
 `executionTime` = a scheduling/scaling problem (cold start, throttle, `IN_QUEUE`), not a slow
-handler. The `workerId` is your handle for the next step.
+handler. The `workerId` is your handle for the next step. Note that a retry **resets**
+`delayTime` to the wait before the final attempt — the 61 s → 101 s jump above is the retry, not
+a lengthening queue.
+
+> **Do not trust the `error` string alone.** `"job timed out after 1 retries"` reads like a
+> capacity or timeout problem. The worker log (next section) showed the actual cause was the
+> empty payload — see the worked example below. This is the failure mode written up in
+> [`../../runpod-usage/reference/gotchas.md`](../../runpod-usage/reference/gotchas.md)
+> ("Serverless job goes `IN_PROGRESS` then times out"), reproduced here live.
 
 > **Job-state semantics** live in
 > [`../../runpod-usage/reference/endpoint-workflows.md`](../../runpod-usage/reference/endpoint-workflows.md);
 > always `/run` + poll `/status` (bound the loop) rather than blocking on `/runsync` for
-> anything slow.
+> anything slow. `runpodctl serverless run` does exactly that for you.
 
 ## 3. Worker logs — what the worker actually did
 
 Endpoint (aggregate, 90-day retained) logs and per-worker (ephemeral, on-host) logs are both
 in the Console (**Logs** and **Workers** tabs). For programmatic/agent access there are two
-routes; there is **no `runpodctl` worker-log command**.
+routes; `runpodctl` has no worker-log command, so this is the one signal the CLI lane cannot
+give you.
 
 ### Route A — v2 REST logs (SSE)
 ```bash
 # workerId comes from /status.workerId or the workers list below
-curl -sN "https://v2-rest.runpod.io/v2/serverless/<endpoint-id>/workers/<worker-id>/logs?source=container&tail=100" \
+curl -sN -m 20 "https://v2-rest.runpod.io/v2/serverless/<endpoint-id>/workers/<worker-id>/logs?source=container&tail=100" \
   -H "Authorization: Bearer $RUNPOD_API_KEY" -H 'Accept: text/event-stream'
 ```
-It's a **Server-Sent Events** stream (`data: {"source","line","ts"}` frames); bound it with
-`curl -m <sec>`. Query params: `source=container|system` (omit for both), `tail=<N>`
-(historical lines to backfill, API default 100, max 5000; `0` = live only), `since=<RFC3339>`
-(resume from a timestamp).
+It's a **Server-Sent Events** stream — each frame is an `id:` line carrying the timestamp plus a
+`data: {"source","line","ts"}` line; bound it with `curl -m <sec>`. Query params:
+`source=container|system` (omit for both), `tail=<N>` (historical lines to backfill, API default
+100, max 5000; `0` = live only), `since=<RFC3339>` (resume from a timestamp; `tail` is ignored
+when it is set).
 
-✅ Live — `source=container` on the worker that served our job showed the full handler-side
-story, correlated to the request by `requestId`:
+✅ Live 2026-08-06 — `source=container` on the worker that served the failed job, showing the
+fitness checks and then the real cause, twice (the original attempt and the retry):
 ```
-data: {"source":"container","line":"--- Starting Serverless Worker |  Version 1.10.1 ---", ...}
-data: {"source":"container","line":"{\"message\":\"Running 7 fitness check(s)...\",\"level\":\"INFO\"}", ...}
-data: {"source":"container","line":"{\"message\":\"All fitness checks passed. (813.77ms)\",\"level\":\"INFO\"}", ...}
-data: {"source":"container","line":"{\"requestId\":\"bb2a...-u1\",\"message\":\"Started.\",\"level\":\"INFO\"}", ...}
-data: {"source":"container","line":"{\"requestId\":\"bb2a...-u1\",\"message\":\"Finished.\",\"level\":\"INFO\"}", ...}
+id: 2026-08-06T17:43:01.179039264Z
+data: {"source":"container","line":"--- Starting Serverless Worker |  Version 1.11.0 ---","ts":"2026-08-06T17:43:01.179039264Z"}
+data: {"source":"container","line":"{\"requestId\": null, \"message\": \"Running 7 fitness check(s)...\", \"level\": \"INFO\"}", ...}
+data: {"source":"container","line":"{\"requestId\": null, \"message\": \"GPU binary test passed: 1 GPU(s) healthy (CUDA 12.8)\", \"level\": \"INFO\"}", ...}
+data: {"source":"container","line":"{\"requestId\": null, \"message\": \"All fitness checks passed. (919.19ms)\", \"level\": \"INFO\"}", ...}
+data: {"source":"container","line":"{\"requestId\": null, \"message\": \"Failed to get job. | Error Type: Exception | Error Message: Job has missing field(s): id or input.\", \"level\": \"ERROR\"}", "ts":"…T17:43:02.47Z"}
+data: {"source":"container","line":"{\"requestId\": null, \"message\": \"Failed to get job. | Error Type: Exception | Error Message: Job has missing field(s): id or input.\", \"level\": \"ERROR\"}", "ts":"…T17:43:42.14Z"}
 ```
-`source=system` carries the host/lifecycle view (image pull/extract progress, worker
-scheduling). Use `container` for your handler's stdout/stderr and the SDK's per-request
-`Started`/`Finished` lines; `system` to diagnose slow cold starts (a long image pull shows up
-here frame by frame).
+That is the whole point of this step: `/status` said *"job timed out after 1 retries"* on a
+worker whose seven fitness checks all passed. The container log says the worker was **healthy
+and rejected the payload**. When a handler does serve a request normally you get per-request
+`Started`/`Finished` lines with a real `requestId` you can match to the job id.
+
+`source=system` carries the host/lifecycle view — ✅ live, the same worker's cold start and
+scale-down:
+```
+data: {"source":"system","line":"create container justinrunpod/vo:v1","ts":"2026-08-06T17:42:52Z"}
+data: {"source":"system","line":"start container for justinrunpod/vo:v1: begin","ts":"2026-08-06T17:42:52Z"}
+data: {"source":"system","line":"model ready","ts":"2026-08-06T17:44:37Z"}
+data: {"source":"system","line":"stop container a6a111ed…","ts":"2026-08-06T17:45:27Z"}
+data: {"source":"system","line":"remove container","ts":"2026-08-06T17:45:30Z"}
+```
+Use `container` for your handler's stdout/stderr and the SDK's per-request lines; `system` to
+diagnose slow cold starts (image pull/extract progress shows up here frame by frame) and to
+confirm a worker actually went away.
 
 To find worker ids without a job in hand, list the endpoint's workers (also v2 REST):
 ```bash
 curl -s https://v2-rest.runpod.io/v2/serverless/<endpoint-id>/workers -H "Authorization: Bearer $RUNPOD_API_KEY"
 ```
-✅ Live — returns a `summary` plus one object per worker with `id`, `status`
-(`RUNNING`/`IDLE`/`THROTTLED`/`INITIALIZING`/`UNHEALTHY`), `gpuTypeId`, `dataCenterId`,
-`image`, `startedAt`, `uptimeSeconds`, `isStale`.
+✅ Live — returns `endpointVersion`, a `summary` (`idle`/`initializing`/`running`/`throttled`/
+`unhealthy`/`total`), and one object per worker with `id`, `status`
+(`RUNNING`/`IDLE`/`THROTTLED`/`INITIALIZING`/`UNHEALTHY`), `gpuTypeId`, `gpuCount`,
+`dataCenterId`, `image`, `startedAt`, `isStale`, `version`:
+```json
+{"dataCenterId":"US-NC-1","gpuCount":1,"gpuTypeId":"NVIDIA GeForce RTX 4090",
+ "id":"z3jr9rv2k3tt2y","image":"justinrunpod/vo:v1","isStale":false,
+ "startedAt":"2026-08-05T21:42:31.705Z","status":"RUNNING","version":2}
+```
+`runpodctl serverless get <id> --include-workers` also lists workers, but it goes through the
+v1 control plane and returns the raw worker records — far more fields, including the endpoint's
+`RUNPOD_AI_API_KEY`/`RUNPOD_ENDPOINT_SECRET` in `env`. Prefer the v2 list (or the MCP tool)
+when you just need ids and states, and don't paste `--include-workers` output into a ticket.
 
 ### Route B — Runpod MCP `stream-worker-logs`
 The hosted Runpod MCP (`https://mcp.getrunpod.io/`) wraps the exact same endpoint as a tool:
 `list-endpoint-workers` → pick a `workerId` → `stream-worker-logs` (params `source`, `tail`,
-`since`, `maxWaitMs`). It returns a bounded, already-parsed snapshot of the frames — the
-easiest route from inside an agent. (This is the same tool golden path
-[07](07-network-volume-handoff.md) used to distinguish a healthy worker from a bad payload.)
+`since`, `maxWaitMs`). It returns a bounded, already-parsed snapshot — `{"items":[{"source",
+"line","ts"}…],"count","truncated"}` — which is the easiest route from inside an agent (✅ used
+live 2026-08-06). This is the same tool golden path
+[07](07-network-volume-handoff.md) used to distinguish a healthy worker from a bad payload.
 
-> Both routes are **v2-only** — they read the v2 serverless service, not `rest.runpod.io/v1`.
-> If you can't reach the v2 logs path, use the MCP tool or the Console **Workers** tab
+> Both routes live on the **v2 serverless REST service** (`v2-rest.runpod.io/v2`), not on
+> `rest.runpod.io/v1` — v1 has no worker-log path at all. That is a statement about which
+> service you call, *not* about the endpoint's own `version` field: ✅ verified live that a
+> `version: 1` endpoint's workers and logs are readable through the v2 route (HTTP 200, real
+> frames). If you can't reach the v2 logs path, use the MCP tool or the Console **Workers** tab
 > (click a worker → its logs + request history).
 
 ## 4. Config-change events (max-workers / region changes fire alerts)
 
 Endpoint config is edited with a v1 `PATCH`; each applied change is a config-change event
-(the same events surface as endpoint alerts/notifications). Verified live 2026-07-13 — both
-toggles returned HTTP 200:
+(the same events surface as endpoint alerts/notifications). `runpodctl serverless update` is
+the first-class wrapper — source-verified in the v2.9.0 tree, it issues exactly that
+`PATCH /endpoints/<id>` against `rest.runpod.io/v1`:
 ```bash
-# scale ceiling
-curl -s -X PATCH https://rest.runpod.io/v1/endpoints/<endpoint-id> \
-  -H "Authorization: Bearer $RUNPOD_API_KEY" -H 'Content-Type: application/json' \
-  -d '{"workersMax":3}'
+# scale ceiling — CLI
+runpodctl serverless update <endpoint-id> --workers-max 3
+# other flags on the same command: --workers-min --idle-timeout --name --template-id
+#                                  --scale-by --scale-threshold --model-reference --clear-models
+# confirm
+runpodctl serverless get <endpoint-id>
+```
+The CLI has **no data-center flag**, so a region change is still a raw `PATCH` (verified live
+2026-07-13, HTTP 200 each):
+```bash
 # network region / data-center set
 curl -s -X PATCH https://rest.runpod.io/v1/endpoints/<endpoint-id> \
   -H "Authorization: Bearer $RUNPOD_API_KEY" -H 'Content-Type: application/json' \
   -d '{"dataCenterIds":["EU-RO-1","EU-CZ-1"]}'
-# confirm
+# ...and the curl equivalent of the CLI call above
+curl -s -X PATCH https://rest.runpod.io/v1/endpoints/<endpoint-id> \
+  -H "Authorization: Bearer $RUNPOD_API_KEY" -H 'Content-Type: application/json' \
+  -d '{"workersMax":3}'
 curl -s https://rest.runpod.io/v1/endpoints/<endpoint-id> -H "Authorization: Bearer $RUNPOD_API_KEY"
 ```
 Changing **max workers** (capacity) or the **network region / data-center** set are the two
@@ -193,35 +293,51 @@ can schedule. Re-read `/health` right after a change to confirm workers redistri
 
 ## The debug loop (putting it together)
 
-1. **`/health`** — is any worker `ready`/`running`? If all `throttled`/`unhealthy` or the
-   endpoint won't scale, that's the problem, not your handler.
-2. **`/status/<jobId>`** — where is the job? Split `delayTime` (queue/scaling) vs.
-   `executionTime` (handler). Grab `workerId`.
-3. **Worker `container` logs** (v2 REST or MCP) for that `workerId` — read the fitness checks
-   and the per-`requestId` lines; a `FAILED` job's traceback is here.
-4. **Config** — if capacity/region is the constraint, `PATCH` `workersMax` / `dataCenterIds`
-   and re-check `/health`.
+1. **`runpodctl serverless health <id>`** — is any worker `ready`/`running`? If all
+   `throttled`/`unhealthy` or the endpoint won't scale, that's the problem, not your handler.
+2. **`runpodctl serverless status <id> <job-id>`** — where is the job? Split `delayTime`
+   (queue/scaling) vs. `executionTime` (handler). Grab `workerId`. Exit code 1 + `job_failed`
+   means the job itself failed, not the call.
+3. **Worker `container` logs** (MCP `stream-worker-logs` or the v2 REST SSE path) for that
+   `workerId` — read the fitness checks and the per-`requestId` lines. A `FAILED` job's real
+   cause is here, and it is often *not* what `/status.error` says.
+4. **Config** — if capacity/region is the constraint, `runpodctl serverless update
+   --workers-max` (or `PATCH` `dataCenterIds`) and re-check health.
 
 ## Gotchas
 - **No `runpodctl` serverless worker-log command** — worker logs come from the v2 REST logs
-  path, the Runpod MCP `stream-worker-logs`, or the Console Workers tab. `runpodctl` covers
-  create/list/delete, not log streaming.
-- **Worker logs are v2-only and ephemeral** — the per-worker stream lives on the host and is
-  gone when the worker terminates. Aggregate **endpoint** logs (Console Logs tab) are retained
-  90 days; for permanent logs, write to a network volume or an external sink.
+  path, the Runpod MCP `stream-worker-logs`, or the Console Workers tab. Everything *else* in
+  this path has a v2.9.0 CLI command: `serverless health`, `serverless status`, `serverless run`,
+  `serverless update`.
+- **`/status.error` can name the wrong culprit** — seen live: `"job timed out after 1 retries"`
+  on a worker whose fitness checks all passed; the container log showed it was rejecting the
+  request payload. Always read the worker log before blaming capacity or the image.
+- **Worker logs are ephemeral, and `container` dies with the container** — ✅ observed: two
+  minutes after the worker's `remove container` system line, `source=container` returned **zero**
+  frames for that worker while `source=system` still returned its lifecycle history. Capture
+  container logs *while the worker is up*. Aggregate **endpoint** logs (Console Logs tab) are
+  retained 90 days; for permanent logs, write to a network volume or an external sink.
 - **Worker logs are SSE, not JSON** — parse `data:` frames and always time-bound the read
-  (`curl -m`), or it will hang tailing live output.
+  (`curl -m`), or it will hang tailing live output. A worker with nothing to say holds the
+  connection open and sends nothing, so an unbounded read simply never returns.
 - **`throttled` is usually transient** — it means the host pool is momentarily constrained
-  (seen live: workers flipped `throttled` then recovered on their own within ~30 s). Only a
-  *persistent* throttle on a narrow/scarce GPU pool needs action (widen GPU types / DCs).
-- **`delayTime` includes cold-start + throttle**, not just queue position — a large
-  `delayTime` on a scale-to-zero endpoint is often just the first worker warming, not a bug.
+  (seen live: workers flipped `throttled` then recovered on their own within ~30 s). A
+  scale-to-zero endpoint can also show a lone `throttled` leftover record while genuinely idle.
+  Only a *persistent* throttle on a narrow/scarce GPU pool needs action (widen GPU types / DCs).
+- **`delayTime` includes cold-start + throttle, and resets on a retry** — a large `delayTime` on
+  a scale-to-zero endpoint is often just the first worker warming. If `retries` ≥ 1, `delayTime`
+  describes the *last* attempt, not the total time since submission.
+- **`/health` and the v2 worker list can disagree** — different views (scheduler gauge vs.
+  worker records), and only `/health` has a `ready` count. Don't treat a mismatch as a bug.
 - **Log throttling** — a worker that floods stdout can have logs dropped; keep handler logging
   structured and modest.
 
 ## Cost & cleanup
 The endpoint is CPU scale-to-zero (`workersMin 0`) — ~$0 idle. All monitoring calls
-(`/health`, `/status`, worker logs, `PATCH`/`GET`) are free.
+(`serverless health`/`status`/`get`, `/health`, `/status`, worker logs, `PATCH`/`GET`) are free;
+only the job itself bills, and the worker returns to idle on its own (✅ confirmed live: the
+worker's `stop container` / `remove container` system lines landed ~1 min after the job went
+terminal).
 ```bash
 runpodctl serverless delete <endpoint-id>
 runpodctl template delete <template-id>
@@ -232,17 +348,23 @@ handler that returns its input plus `RUNPOD_POD_ID`/`RUNPOD_DC_ID`) is left publ
 cites a real, pullable tag; it costs nothing.
 
 ## Skill facts confirmed / folded back
+- **Three of the four signals are first-class CLI commands as of v2.9.0** — `serverless health`
+  and `serverless status` hit the invoke service (`api.runpod.ai/v2`) and pass its JSON through
+  verbatim; `serverless update` `PATCH`es the v1 control plane. Worker logs remain the one
+  signal with no CLI command.
 - **`/health` returns six worker-state fields** (`idle`, `initializing`, `ready`, `running`,
   `throttled`, `unhealthy`) — richer than the `{idle,running}` shape in the operation
-  reference. Worth folding the full set into
-  [endpoint-workflows.md](../../runpod-usage/reference/endpoint-workflows.md), which today
-  only says "diagnose via `/health` worker counts."
+  reference, and richer than the v2 worker-list `summary`, which has no `ready`.
+- **The `job_failed` exit path is real, not just documented** — a terminal `FAILED` job prints
+  its payload on stdout, `{"code":"job_failed"}` on stderr, and exits 1, matching
+  [`../../runpodctl/reference/output-and-errors.md`](../../runpodctl/reference/output-and-errors.md).
+- **`/status` gains `error` and `retries` on the failure path** — and `delayTime` is recomputed
+  per attempt, so `delayTime` + `executionTime` does not reconstruct wall-clock across a retry.
 - **Worker log streaming is a real, reachable v2 REST endpoint** —
   `GET https://v2-rest.runpod.io/v2/serverless/<id>/workers/<workerId>/logs` (SSE, params
-  `source`/`tail`/`since`), and `.../workers` lists workers with status/GPU/DC. The Runpod MCP
-  (`list-endpoint-workers` + `stream-worker-logs`) wraps both.
-- **`/status` timing split** (`delayTime` vs `executionTime` + `workerId`) is the fastest way
-  to classify a slow request as scaling-bound vs. handler-bound.
-- **Config edits are v1 `PATCH`** on `rest.runpod.io/v1/endpoints/<id>` (`workersMax`,
-  `dataCenterIds`, …) — these are the config-change events; confirm with a follow-up `GET` and
-  a fresh `/health`.
+  `source`/`tail`/`since`), and `.../workers` lists workers with status/GPU/DC. Both work for
+  `version: 1` endpoints too. The Runpod MCP (`list-endpoint-workers` + `stream-worker-logs`)
+  wraps both.
+- **`serverless get --include-workers` echoes endpoint secrets** — it returns raw v1 worker
+  records including `RUNPOD_AI_API_KEY`/`RUNPOD_ENDPOINT_SECRET` in `env`. Use the v2 worker
+  list when you only need ids and states.

--- a/plugins/runpod/skills/runpod/golden-paths/19-three-region-same-file.md
+++ b/plugins/runpod/skills/runpod/golden-paths/19-three-region-same-file.md
@@ -317,5 +317,3 @@ pullable tag; it costs nothing.
   field) is worth folding into
   [endpoint-workflows.md](../../runpod-usage/reference/endpoint-workflows.md) alongside
   the multi-volume version note from 10.
-</content>
-</invoke>

--- a/plugins/runpod/skills/runpod/golden-paths/README.md
+++ b/plugins/runpod/skills/runpod/golden-paths/README.md
@@ -70,7 +70,7 @@ observed output) → Gotchas we hit → Cost & cleanup → Skill gaps folded bac
 | 12 | [Serverless streaming (`/stream`)](12-serverless-streaming.md) | serverless | generator handler + `/stream` | ✅ live-verified |
 | 13 | [Autoscaling tuning](13-autoscaling-tuning.md) | serverless / scaling | runpodctl + scaler config (queue-delay / request-count) | ✅ live-verified |
 | 14 | [Load-balancing endpoint (non-flash)](14-load-balancing-endpoint.md) | serverless / LB | GraphQL `saveEndpoint type:"LB"` + HTTP-server worker | ✅ live-verified |
-| 15 | [Monitor & debug / observability](15-monitor-and-debug.md) | serverless / ops | `runpodctl serverless health`/`status` (or `/health` + `/status`) + worker logs (v2 / MCP) + config-change events | ✅ live-verified |
+| 15 | [Monitor & debug / observability](15-monitor-and-debug.md) | serverless / ops | `runpodctl serverless health`/`status`/`logs` (or `/health` + `/status` + v2 REST / MCP worker logs) + config-change events | ✅ live-verified |
 | 16 | [Serverless webhooks](16-serverless-webhooks.md) | serverless | `webhook` field on `/run` (push vs poll) | ✅ live-verified |
 | 17 | [Serverless WebSocket worker](17-serverless-websocket.md) | serverless / LB | `worker-lb-websocket` + `wss://<ep>.api.runpod.ai/ws` | ✅ live-verified |
 | 18 | [Concurrent handler (per-worker concurrency)](18-concurrent-handler.md) | serverless / throughput | async `concurrency_modifier` | ✅ live-verified |

--- a/plugins/runpod/skills/runpod/golden-paths/README.md
+++ b/plugins/runpod/skills/runpod/golden-paths/README.md
@@ -70,7 +70,7 @@ observed output) → Gotchas we hit → Cost & cleanup → Skill gaps folded bac
 | 12 | [Serverless streaming (`/stream`)](12-serverless-streaming.md) | serverless | generator handler + `/stream` | ✅ live-verified |
 | 13 | [Autoscaling tuning](13-autoscaling-tuning.md) | serverless / scaling | runpodctl + scaler config (queue-delay / request-count) | ✅ live-verified |
 | 14 | [Load-balancing endpoint (non-flash)](14-load-balancing-endpoint.md) | serverless / LB | GraphQL `saveEndpoint type:"LB"` + HTTP-server worker | ✅ live-verified |
-| 15 | [Monitor & debug / observability](15-monitor-and-debug.md) | serverless / ops | `/health` + worker logs (v2 / MCP) + config-change events | ✅ live-verified |
+| 15 | [Monitor & debug / observability](15-monitor-and-debug.md) | serverless / ops | `runpodctl serverless health`/`status` (or `/health` + `/status`) + worker logs (v2 / MCP) + config-change events | ✅ live-verified |
 | 16 | [Serverless webhooks](16-serverless-webhooks.md) | serverless | `webhook` field on `/run` (push vs poll) | ✅ live-verified |
 | 17 | [Serverless WebSocket worker](17-serverless-websocket.md) | serverless / LB | `worker-lb-websocket` + `wss://<ep>.api.runpod.ai/ws` | ✅ live-verified |
 | 18 | [Concurrent handler (per-worker concurrency)](18-concurrent-handler.md) | serverless / throughput | async `concurrency_modifier` | ✅ live-verified |

--- a/plugins/runpod/skills/runpodctl/SKILL.md
+++ b/plugins/runpod/skills/runpodctl/SKILL.md
@@ -128,7 +128,7 @@ commands, `project`), and the env-var table (incl. `RUNPOD_INVOKE_URL`):
 - Use serverless for request/response inference APIs and scalable workers; use pods for interactive work, notebooks, training, debugging, or long-lived sessions.
 - Use CPU pods for preprocessing, file movement, lightweight scripts, and non-CUDA work. Use GPU pods when CUDA, model inference, training, or GPU memory is required.
 - Do not pass GPU flags when creating CPU pods. Check `runpodctl pod create --help` for the current valid flag set.
-- **Waiting for a resource to be usable: use `--wait`, don't hand-roll a poll loop** (v2.9.0+). `create` returns as soon as the resource is *scheduled*, which is why a "RUNNING" pod often refuses ssh and a fresh endpoint 404s. `pod create --wait` returns when port 22 answers with an ssh banner; `serverless create --wait` when `/health` reports a ready or running worker. On timeout or ctrl-c the resource is **kept** and its id is in the error object's `id` field — so a wait that gives up never silently leaks a billed resource, but you do have to clean it up.
+- **Waiting for a resource to be usable: use `--wait`, don't hand-roll a poll loop** (v2.9.0+). `create` returns as soon as the resource is *scheduled*, which is why a "RUNNING" pod often refuses ssh and a fresh endpoint 404s. `pod create --wait` returns when port 22 answers with an ssh banner; `serverless create --wait` when `/health` reports a ready or running worker. On timeout or ctrl-c the resource is **kept**, and its id is in the error object's `id` field — read that and clean up, don't assume nothing was created (a pod bills by the second; an endpoint with no running worker doesn't, but will start one on the first request).
 - Standing up a **service on a pod** (Ollama, ComfyUI, a dev server)? Declare its `--ports` and `--env` **at creation** (they can't be added to a running pod without a reset), then follow the pod development loop in the `runpod-usage` skill (`reference/pod-workflows.md`) — SSH-exec the install, bind to `0.0.0.0`, and poll the proxy URL until it answers.
 - For SSH, use `runpodctl pod get <pod-id>` or `runpodctl ssh info <pod-id>` to retrieve connection details. runpodctl has **no interactive-shell command** — `ssh info` returns the connection command + key but does not connect. Run commands over SSH yourself with `ssh user@host "command"`.
 - Network volumes are location-sensitive. Check datacenter availability before attaching volumes, and use `send` / `receive` or S3-compatible storage for migrations.
@@ -158,13 +158,10 @@ runpodctl pod create --image <img> --gpu-id <id> --wait                      # b
 runpodctl pod {start|stop|restart|reset|update|delete} <pod-id>              # lifecycle (delete aliases: rm/remove)
 ```
 
-**Read `runtimeStatus`, not `desiredStatus`, to decide whether a pod is usable** (v2.9.0+).
-`desiredStatus: RUNNING` only means the platform intends it to run — it says that while the
-image is still being pulled. `runtimeStatus` is one of `running`, `initializing`, `stopped`,
-`terminated`, `unknown`, with a `runtimeStatusReason` token when there is more to say, and
-`uptimeSeconds` is present only while the container is actually up. Two edges worth knowing:
-`--status` filters `desiredStatus` only (`--status initializing` matches nothing), and
-`unknown` means "the lookup failed", not "the pod is down".
+**Read `runtimeStatus`, not `desiredStatus`, to decide whether a pod is usable** (v2.9.0+):
+`desiredStatus: RUNNING` says that while the image is still pulling. Field meanings, reason
+tokens, and two edges (`--status` filters `desiredStatus` only; `unknown` = lookup failed, not
+pod down) → [reference/command-reference.md](reference/command-reference.md#pod-status-fields).
 
 ### Hub
 
@@ -205,21 +202,14 @@ runpodctl serverless status <endpoint-id> <job-id>                    # check a 
 runpodctl serverless health <endpoint-id>                             # worker + job counts
 ```
 
-- **The payload is the handler payload, not the whole envelope.** It is sent as
-  `{"input": <your json>}`, must be a json object, and is parsed + size-checked locally, so a
-  quoting mistake or an over-limit body fails as `usage_error` before anything uploads.
-- **stdout is always the job payload — even for a `FAILED` job**, because the worker's own
-  error is the useful artifact. Progress notes and error objects go to stderr, so
-  `... 2>/dev/null | jq` sees exactly one json object.
+- **Pass only the handler payload** — the cli wraps it as `{"input": <your json>}` itself, so
+  pasting a whole curl envelope double-wraps it.
 - **`timeout` means the cli stopped waiting, not that the endpoint broke.** When the message
   names a `serverless status` command the job is still running server-side — poll it, do
-  **not** re-invoke (that buys a second job). When it doesn't, nothing is running and a retry
-  is fine.
-- Exit codes: `0` when the job `COMPLETED` (and when `--no-wait`/`--wait 0` submitted it),
-  `1` when the request fails, the wait budget runs out (`timeout`), or the job ends
-  `FAILED`/`CANCELLED`/`TIMED_OUT` (`job_failed`).
-- `run` submits on `/run` and polls `/status` — never `/runsync`, which is not actually
-  synchronous and whose results expire after 1 minute (30 for `/run`).
+  **not** re-invoke (that buys a second job).
+
+Payload rules, the stdout/stderr split, exit codes and why `/runsync` is never used →
+[reference/command-reference.md](reference/command-reference.md#invoking-an-endpoint-v290).
 
 **Create from hub:** `--hub-id` resolves the hub listing, extracts the build image and config (GPU IDs, container disk, env vars), creates an inline template, and deploys. Accepts both SERVERLESS and POD listing types. GPU IDs and env var defaults from the hub config are included automatically; override with `--gpu-id` and `--env`.
 
@@ -336,10 +326,9 @@ Example: `https://abc123xyz-8888.proxy.runpod.net`
 
 ### Serverless URLs
 
-Prefer `runpodctl serverless run|status|health` (above) over calling these by hand — same api,
-with auth, local payload validation, bounded polling and machine-readable errors already
-handled. Reach for the raw urls when you need something the commands do not cover (streaming,
-the OpenAI-compatible route, or handing a user a copy-paste `curl`):
+Prefer `runpodctl serverless run|status|health` (above) — same api, with auth, validation and
+bounded polling handled. Use the raw urls for what the commands don't cover: streaming, the
+OpenAI-compatible route, or a copy-paste `curl` for a user.
 
 ```
 https://api.runpod.ai/v2/<endpoint-id>/run        # Async request

--- a/plugins/runpod/skills/runpodctl/SKILL.md
+++ b/plugins/runpod/skills/runpodctl/SKILL.md
@@ -128,6 +128,7 @@ commands, `project`), and the env-var table (incl. `RUNPOD_INVOKE_URL`):
 - Use serverless for request/response inference APIs and scalable workers; use pods for interactive work, notebooks, training, debugging, or long-lived sessions.
 - Use CPU pods for preprocessing, file movement, lightweight scripts, and non-CUDA work. Use GPU pods when CUDA, model inference, training, or GPU memory is required.
 - Do not pass GPU flags when creating CPU pods. Check `runpodctl pod create --help` for the current valid flag set.
+- **Waiting for a resource to be usable: use `--wait`, don't hand-roll a poll loop** (v2.9.0+). `create` returns as soon as the resource is *scheduled*, which is why a "RUNNING" pod often refuses ssh and a fresh endpoint 404s. `pod create --wait` returns when port 22 answers with an ssh banner; `serverless create --wait` when `/health` reports a ready or running worker. On timeout or ctrl-c the resource is **kept** and its id is in the error object's `id` field — so a wait that gives up never silently leaks a billed resource, but you do have to clean it up.
 - Standing up a **service on a pod** (Ollama, ComfyUI, a dev server)? Declare its `--ports` and `--env` **at creation** (they can't be added to a running pod without a reset), then follow the pod development loop in the `runpod-usage` skill (`reference/pod-workflows.md`) — SSH-exec the install, bind to `0.0.0.0`, and poll the proxy URL until it answers.
 - For SSH, use `runpodctl pod get <pod-id>` or `runpodctl ssh info <pod-id>` to retrieve connection details. runpodctl has **no interactive-shell command** — `ssh info` returns the connection command + key but does not connect. Run commands over SSH yourself with `ssh user@host "command"`.
 - Network volumes are location-sensitive. Check datacenter availability before attaching volumes, and use `send` / `receive` or S3-compatible storage for migrations.
@@ -139,7 +140,7 @@ commands, `project`), and the env-var table (incl. `RUNPOD_INVOKE_URL`):
 
 - **Scale-to-zero billing:** serverless endpoints scale to zero with `--workers-min 0` (the default) — no GPU billing while idle, only per request-second; this is the right cost posture for a request/response API.
 - **Broken-image tell:** if deployed workers go `ready` but jobs sit `IN_QUEUE` with `inProgress: 0`, the image is broken/mis-dispatching — the fix is to switch to a different worker rather than wait it out.
-- **Diagnosing it:** there's no first-class serverless worker-log command, so diagnosis relies on `/health` worker counts.
+- **Diagnosing it:** read the worker/job counts with `runpodctl serverless health <endpoint-id>` (v2.9.0+) — no hand-built curl needed. runpodctl still has no worker-*log* command; the MCP lane does (`stream worker logs`).
 
 ## Commands
 
@@ -149,12 +150,21 @@ Essentials below. **Full flag menu → [reference/command-reference.md](referenc
 
 ```bash
 runpodctl pod list                                   # running pods (+ --all / --status / --since / --created-after)
-runpodctl pod get <pod-id>                           # details incl. SSH info
+runpodctl pod get <pod-id>                           # details incl. SSH info + runtimeStatus
 runpodctl pod create --template-id <id> --gpu-id "NVIDIA GeForce RTX 4090"   # from template
 runpodctl pod create --image <img> --gpu-id "NVIDIA GeForce RTX 4090"        # from image
 runpodctl pod create --compute-type cpu --image ubuntu:22.04                 # CPU pod (lowercase `cpu`; serverless uses `CPU`)
+runpodctl pod create --image <img> --gpu-id <id> --wait                      # block until ssh answers, then print the pod (v2.9.0+)
 runpodctl pod {start|stop|restart|reset|update|delete} <pod-id>              # lifecycle (delete aliases: rm/remove)
 ```
+
+**Read `runtimeStatus`, not `desiredStatus`, to decide whether a pod is usable** (v2.9.0+).
+`desiredStatus: RUNNING` only means the platform intends it to run — it says that while the
+image is still being pulled. `runtimeStatus` is one of `running`, `initializing`, `stopped`,
+`terminated`, `unknown`, with a `runtimeStatusReason` token when there is more to say, and
+`uptimeSeconds` is present only while the container is actually up. Two edges worth knowing:
+`--status` filters `desiredStatus` only (`--status initializing` matches nothing), and
+`unknown` means "the lookup failed", not "the pod is down".
 
 ### Hub
 
@@ -174,6 +184,7 @@ runpodctl serverless create --name "x" --hub-id <listing-id>    # from hub (+ --
 runpodctl serverless create --hub-id <id> --gpu-id "NVIDIA GeForce RTX 4090" \
   --model-reference https://huggingface.co/<org>/<model>:main   # attach & host-cache a HF model (GPU only)
 runpodctl serverless update <endpoint-id> --workers-max 5
+runpodctl serverless create --template-id <id> --workers-min 1 --wait          # block until a worker is ready (v2.9.0+)
 ```
 
 **Invoke URLs come back with the endpoint.** `create`/`get`/`list`/`update` include a
@@ -181,6 +192,34 @@ runpodctl serverless update <endpoint-id> --workers-max 5
 without a second lookup — read them instead of assembling the URL yourself. They're
 built from `RUNPOD_INVOKE_URL` (default `https://api.runpod.ai/v2`), which
 `RUNPOD_API_URL`/`RUNPOD_GRAPHQL_URL` do **not** move: [reference/output-and-errors.md](reference/output-and-errors.md#serverless-invoke-urls).
+
+**Invoking an endpoint** (v2.9.0+) — first-class commands, so an agent does not hand-build a
+curl request or manage a bearer token:
+
+```bash
+runpodctl serverless run <endpoint-id> --input '{"prompt":"hello"}'   # submit and wait for the result
+runpodctl serverless run <endpoint-id> --input-file payload.json      # same, payload from a file ("-" = stdin)
+runpodctl serverless run <endpoint-id> --input '{}' --wait 15m        # longer budget (default 5m)
+runpodctl serverless run <endpoint-id> --input '{}' --no-wait         # submit, print the queued job, exit 0
+runpodctl serverless status <endpoint-id> <job-id>                    # check a job submitted earlier
+runpodctl serverless health <endpoint-id>                             # worker + job counts
+```
+
+- **The payload is the handler payload, not the whole envelope.** It is sent as
+  `{"input": <your json>}`, must be a json object, and is parsed + size-checked locally, so a
+  quoting mistake or an over-limit body fails as `usage_error` before anything uploads.
+- **stdout is always the job payload — even for a `FAILED` job**, because the worker's own
+  error is the useful artifact. Progress notes and error objects go to stderr, so
+  `... 2>/dev/null | jq` sees exactly one json object.
+- **`timeout` means the cli stopped waiting, not that the endpoint broke.** When the message
+  names a `serverless status` command the job is still running server-side — poll it, do
+  **not** re-invoke (that buys a second job). When it doesn't, nothing is running and a retry
+  is fine.
+- Exit codes: `0` when the job `COMPLETED` (and when `--no-wait`/`--wait 0` submitted it),
+  `1` when the request fails, the wait budget runs out (`timeout`), or the job ends
+  `FAILED`/`CANCELLED`/`TIMED_OUT` (`job_failed`).
+- `run` submits on `/run` and polls `/status` — never `/runsync`, which is not actually
+  synchronous and whose results expire after 1 minute (30 for `/run`).
 
 **Create from hub:** `--hub-id` resolves the hub listing, extracts the build image and config (GPU IDs, container disk, env vars), creates an inline template, and deploys. Accepts both SERVERLESS and POD listing types. GPU IDs and env var defaults from the hub config are included automatically; override with `--gpu-id` and `--env`.
 
@@ -296,6 +335,11 @@ https://<pod-id>-<port>.proxy.runpod.net
 Example: `https://abc123xyz-8888.proxy.runpod.net`
 
 ### Serverless URLs
+
+Prefer `runpodctl serverless run|status|health` (above) over calling these by hand — same api,
+with auth, local payload validation, bounded polling and machine-readable errors already
+handled. Reach for the raw urls when you need something the commands do not cover (streaming,
+the OpenAI-compatible route, or handing a user a copy-paste `curl`):
 
 ```
 https://api.runpod.ai/v2/<endpoint-id>/run        # Async request

--- a/plugins/runpod/skills/runpodctl/SKILL.md
+++ b/plugins/runpod/skills/runpodctl/SKILL.md
@@ -121,6 +121,7 @@ commands, `project`), and the env-var table (incl. `RUNPOD_INVOKE_URL`):
   - **Picking a worker:** prefer a **first-party or well-adopted, recently-released** worker on a **broad, high-availability GPU pool**. Observable signals via `runpodctl hub list`: `--owner runpod-workers` (first-party), `--order-by releasedAt`/`updatedAt` (recency), `--order-by deploys`/`stars` (adoption). Don't pin a scarce large-GPU tier a small model doesn't need.
 - **"Active worker" = minimum workers, not maximum.** If a user asks for an "active worker," they mean `--workers-min 1` (keep one worker always warm → no cold start), **not** `--workers-max 1` (that only caps the ceiling). A warm min-1 worker is ideal for development/iteration.
 - ⚠️ **A min-1 worker bills continuously, even while idle** (it defeats scale-to-zero). When you set `--workers-min 1` for dev, you **must** set it back to `--workers-min 0` (or delete the endpoint) when done — otherwise it quietly runs up cost.
+  - **Needs runpodctl ≥ v2.10.0.** On earlier binaries `--workers-min 0` and `--idle-timeout 0` were **silently dropped** from the update request (`omitempty` ate the zero), so the reset looked like it applied and the endpoint kept billing. Check `runpodctl version`; on an older binary confirm with `serverless get <id>` and fall back to `PATCH https://rest.runpod.io/v1/endpoints/<id>` with an explicit `{"workersMin":0}`.
 - `serverless update` has **no `--gpu-id` flag**. To change an existing endpoint's GPU pool, call `PATCH https://rest.runpod.io/v1/endpoints/<id>` with `{"gpuTypeIds":[...]}` directly.
 - **CPU serverless endpoints:** always create them with `runpodctl serverless create --compute-type CPU` — **not** the MCP server, whose v2 `create-endpoint` requires `gpuPoolIds` and has no CPU concept. **Never** use the public control REST `POST https://rest.runpod.io/v1/endpoints` with `"computeType":"CPU"` — it silently provisions a **GPU** endpoint instead (verified evidence in the Serverless command section below).
 - Use templates when the user already has a template ID, wants reusable image/config defaults, or needs lower-level control than Hub.
@@ -140,7 +141,7 @@ commands, `project`), and the env-var table (incl. `RUNPOD_INVOKE_URL`):
 
 - **Scale-to-zero billing:** serverless endpoints scale to zero with `--workers-min 0` (the default) — no GPU billing while idle, only per request-second; this is the right cost posture for a request/response API.
 - **Broken-image tell:** if deployed workers go `ready` but jobs sit `IN_QUEUE` with `inProgress: 0`, the image is broken/mis-dispatching — the fix is to switch to a different worker rather than wait it out.
-- **Diagnosing it:** read the worker/job counts with `runpodctl serverless health <endpoint-id>` (v2.9.0+) — no hand-built curl needed. runpodctl still has no worker-*log* command; the MCP lane does (`stream worker logs`).
+- **Diagnosing it:** read the worker/job counts with `runpodctl serverless health <endpoint-id>` (v2.9.0+), then read what the workers actually printed with `runpodctl serverless logs <endpoint-id>` (v2.10.0+) — no hand-built curl needed. Repeated `system` "start container" lines with no `container` output means the container exits before the handler runs.
 
 ## Commands
 
@@ -156,7 +157,14 @@ runpodctl pod create --image <img> --gpu-id "NVIDIA GeForce RTX 4090"        # f
 runpodctl pod create --compute-type cpu --image ubuntu:22.04                 # CPU pod (lowercase `cpu`; serverless uses `CPU`)
 runpodctl pod create --image <img> --gpu-id <id> --wait                      # block until ssh answers, then print the pod (v2.9.0+)
 runpodctl pod {start|stop|restart|reset|update|delete} <pod-id>              # lifecycle (delete aliases: rm/remove)
+runpodctl pod logs <pod-id>                          # recent container+system logs, json lines (v2.10.0+)
+runpodctl pod logs <pod-id> --follow                 # keep streaming, reconnects on its own
+runpodctl pod logs <pod-id> --since 30m --source system   # platform view: image pull / create / start
 ```
+
+**A stalled deploy shows up in `--source system`** (v2.10.0+): repeated pull progress, or a
+`create container` that never reaches `start`. Use `--source container` for your workload's own
+output. Each line is one `{source,line,ts}` object, so pipe it straight to `jq`.
 
 **Read `runtimeStatus`, not `desiredStatus`, to decide whether a pod is usable** (v2.9.0+):
 `desiredStatus: RUNNING` says that while the image is still pulling. Field meanings, reason
@@ -190,6 +198,21 @@ without a second lookup — read them instead of assembling the URL yourself. Th
 built from `RUNPOD_INVOKE_URL` (default `https://api.runpod.ai/v2`), which
 `RUNPOD_API_URL`/`RUNPOD_GRAPHQL_URL` do **not** move: [reference/output-and-errors.md](reference/output-and-errors.md#serverless-invoke-urls).
 
+**Reading worker logs** (v2.10.0+) — also first-class, so worker output no longer requires the
+MCP lane or a hand-built SSE read:
+
+```bash
+runpodctl serverless logs <endpoint-id>                       # every worker's recent logs, json lines
+runpodctl serverless logs <endpoint-id> --worker <worker-id>  # just one worker
+runpodctl serverless logs <endpoint-id> --follow              # picks up workers that scale up mid-follow
+runpodctl serverless logs <endpoint-id> --since 1h --source system   # why a worker will not start
+```
+
+Logs belong to a **worker**, not the endpoint, so without `--worker` this reads them all at once and
+tags each line with its `workerId`. **The crash-loop tell:** repeated `system` "start container" lines
+with no `container` output means the container exits before the handler runs — jobs then sit in the
+queue with nothing wrong with capacity.
+
 **Invoking an endpoint** (v2.9.0+) — first-class commands, so an agent does not hand-build a
 curl request or manage a bearer token:
 
@@ -209,7 +232,7 @@ runpodctl serverless health <endpoint-id>                             # worker +
   **not** re-invoke (that buys a second job).
 
 Payload rules, the stdout/stderr split, exit codes and why `/runsync` is never used →
-[reference/command-reference.md](reference/command-reference.md#invoking-an-endpoint-v290).
+[reference/command-reference.md](reference/command-reference.md#invoking-an-endpoint-serverless-run-v290).
 
 **Create from hub:** `--hub-id` resolves the hub listing, extracts the build image and config (GPU IDs, container disk, env vars), creates an inline template, and deploys. Accepts both SERVERLESS and POD listing types. GPU IDs and env var defaults from the hub config are included automatically; override with `--gpu-id` and `--env`.
 

--- a/plugins/runpod/skills/runpodctl/SKILL.md
+++ b/plugins/runpod/skills/runpodctl/SKILL.md
@@ -145,7 +145,7 @@ commands, `project`), and the env-var table (incl. `RUNPOD_INVOKE_URL`):
 
 ## Commands
 
-Essentials below. **Full flag menu → [reference/command-reference.md](reference/command-reference.md)** (pods lifecycle, hub/template filters, registry auth, billing, SSH key management); live `runpodctl <resource> <action> --help` is authoritative for exact flags.
+Essentials below. **For flags, ask the binary** — `runpodctl <resource> <action> --help`, which is current by construction. [reference/command-reference.md](reference/command-reference.md) holds the part `--help` cannot answer: what a flag *means* when it succeeds, which field to trust, and what a failure looks like.
 
 ### Pods
 

--- a/plugins/runpod/skills/runpodctl/evals/create-and-wait-until-usable.eval.md
+++ b/plugins/runpod/skills/runpodctl/evals/create-and-wait-until-usable.eval.md
@@ -1,0 +1,26 @@
+# Create a pod and wait until it is actually usable
+
+## Prompt
+
+Spin me up an A40 pod from `runpod/pytorch:1.0.3-cu1281-torch291-ubuntu2404` and
+tell me when I can ssh into it.
+
+## Expected behavior
+
+The agent should:
+
+1. Create with `runpodctl pod create --image ... --gpu-id "NVIDIA A40" --wait`, which returns
+   only once port 22 answers with an ssh banner.
+2. Read the printed payload (the `pod get` shape, so it carries the live `ssh` block) and give
+   the user the ssh command.
+3. NOT write its own poll loop around `pod get`/`ssh info`, and NOT treat
+   `desiredStatus: RUNNING` as "ready" — that is true while the image is still pulling.
+4. If the wait times out, recognise that the pod **was created and still bills**, take the id
+   from the error object's `id` field, and offer to delete it.
+
+## Assertions
+
+- Uses `--wait` (optionally with `--wait-timeout`) rather than a hand-rolled polling loop
+- Does not claim the pod is ready based on `desiredStatus` alone; if it inspects status, it reads `runtimeStatus`
+- Reports the ssh connection details from the waited-for output
+- On `wait_timeout` / `wait_interrupted`, surfaces the pod id from the error object and proposes cleanup instead of assuming nothing was created

--- a/plugins/runpod/skills/runpodctl/evals/error-handling.eval.md
+++ b/plugins/runpod/skills/runpodctl/evals/error-handling.eval.md
@@ -19,7 +19,7 @@ The agent should:
 2. Explain that the second failure has no `status` because GraphQL answers a missing
    resource with HTTP 200 + null data, so `status === 404` misses it
 3. Retry `network_error`, `rate_limited` and `server_error` with backoff, and say why
-   `cli_error` (e.g. malformed `RUNPOD_API_URL`, a timed-out local wait loop) must not be
+   `cli_error` (e.g. a malformed `RUNPOD_API_URL`) must not be
 4. Distinguish `no_credentials` (no key set → `RUNPOD_API_KEY` / `runpodctl doctor`) from
    `unauthorized` (key present but wrong/expired) — neither is a retry
 5. Treat `not_found` as server-side, not as a mistyped local path
@@ -27,6 +27,10 @@ The agent should:
    not treat a `warning:`/`note:` line on stderr as a failure
 7. Include a default branch for an unrecognized `code`, because the vocabulary is what the
    CLI generates rather than exhaustive (the API can pass its own code through lowercased)
+8. Not retry `timeout` / `wait_timeout` / `wait_interrupted` / `job_failed` (v2.9.0+): each
+   means work or a resource outlived the CLI, so re-running the command buys a **second**
+   job or a second billed resource. Follow up instead — poll (`serverless status`, `pod get`)
+   or clean up via the error object's `id`
 
 ## Assertions
 
@@ -36,6 +40,8 @@ The agent should:
 - The produced handler has a default/else branch treating an unknown `code` as fatal
 - Does NOT retry `cli_error`, `usage_error`, `not_found`, `no_credentials`, or
   `unauthorized`
+- Does NOT retry `timeout`, `wait_timeout`, `wait_interrupted` or `job_failed`; treats them
+  as "poll or clean up", not as "run it again"
 - Separates `no_credentials` from `unauthorized` in the auth handling
 - Reads errors from stderr and does NOT expect error JSON on stdout
 - Does NOT claim `status` is always present

--- a/plugins/runpod/skills/runpodctl/evals/error-handling.eval.md
+++ b/plugins/runpod/skills/runpodctl/evals/error-handling.eval.md
@@ -46,4 +46,8 @@ The agent should:
 - Reads errors from stderr and does NOT expect error JSON on stdout
 - Does NOT claim `status` is always present
 - Does NOT tell the user to parse plaintext for `pod`/`serverless`/`template`/`model`
-  commands (only the legacy `pod` paths, `exec` and `project` still print plaintext)
+  commands (on v2.10.0+ only the legacy `pod` paths and `project` still print plaintext —
+  `exec` joined the coded-JSON shape and now exits non-zero, so an assertion that names
+  `exec` as a plaintext surface is stale)
+- Does NOT pass `--output` anything but `json`/`yaml`: on v2.10.0+ an unrecognized value is
+  a `usage_error` with exit 1, where v2.9.0 silently returned JSON

--- a/plugins/runpod/skills/runpodctl/evals/serverless-invoke-job.eval.md
+++ b/plugins/runpod/skills/runpodctl/evals/serverless-invoke-job.eval.md
@@ -1,0 +1,26 @@
+# Invoke a serverless endpoint and get the result
+
+## Prompt
+
+I have a serverless endpoint `ep-abc123` running a vLLM worker. Send it
+`{"prompt": "why is the sky blue?"}` and show me what it returns.
+
+## Expected behavior
+
+The agent should:
+
+1. Invoke with `runpodctl serverless run ep-abc123 --input '{"prompt":"why is the sky blue?"}'`,
+   which submits the job and polls until it is terminal.
+2. Pass only the **handler** payload — the cli wraps it as `{"input": ...}` itself.
+3. Read the job payload off stdout (it is printed even when the job fails) and report the
+   worker's output or its `error`.
+4. If the wait budget runs out with a `timeout` code whose message names a
+   `serverless status` command, poll that command rather than re-invoking.
+
+## Assertions
+
+- Uses `runpodctl serverless run ep-abc123` with `--input` (or `--input-file`)
+- Does NOT hand-build a `curl` to `https://api.runpod.ai/v2/ep-abc123/run` or `/runsync`, and does NOT construct an `Authorization: Bearer` header by hand
+- Does NOT double-wrap the payload as `{"input":{"prompt":...}}`
+- On a `timeout`, polls with `runpodctl serverless status ep-abc123 <job-id>` instead of re-submitting the job
+- Treats a `job_failed` exit as the worker's failure (payload on stdout), not as a cli/auth problem

--- a/plugins/runpod/skills/runpodctl/reference/command-reference.md
+++ b/plugins/runpod/skills/runpodctl/reference/command-reference.md
@@ -44,7 +44,7 @@ Output shapes, error codes and env vars are in
 | `runtimeStatusReason` | stable token when there is more to say, e.g. `awaiting_container`, `stopped_by_user`, `stopped_by_runpod`, `terminated_outbid`, `runtime_unavailable` |
 | `uptimeSeconds` | present only while the container is up; omitted otherwise (it used to be a constant `0`) |
 | `lastStatusChange` | the backend's raw free-text note, carried so a phrasing the cli does not tokenise still reaches you |
-| `networkVolumeId` | **v2.10.0+:** always present when the pod has a volume attached, with or without `--include-network-volume`; `--include-network-volume` additionally fills the full `networkVolume` object. On **v2.9.0 and earlier both were dropped on deserialization** and read back `null` even when a volume was attached — so a pre-v2.10.0 binary cannot be used to check whether a pod has one |
+| `networkVolumeId` / `networkVolume` | **v2.10.0+:** `pod get --include-network-volume` fills both — the id and the full volume object. On **v2.9.0 and earlier both were dropped on deserialization** and read back `null` even with the flag, so a pre-v2.10.0 binary cannot tell you whether a pod has a volume. Upstream reports the `networkVolumeId` also comes back *without* the flag now (it is free alongside the pod), but only the flagged path is covered by a test — pass `--include-network-volume` rather than relying on that |
 
 `--status` filters **`desiredStatus` only** — `--status initializing` silently matches nothing.
 

--- a/plugins/runpod/skills/runpodctl/reference/command-reference.md
+++ b/plugins/runpod/skills/runpodctl/reference/command-reference.md
@@ -1,32 +1,26 @@
-# runpodctl — full command reference
+# runpodctl — behavior reference
 
-Live `runpodctl <resource> <action> --help` is always authoritative for exact flags. This
-is the fuller menu (the SKILL keeps the 80% essentials); use it for the long-tail flags.
+**This file does not list flags.** `runpodctl <resource> <action> --help` does, it is always
+current, and it ships with the binary in front of you:
 
+```bash
+runpodctl --help                          # resources
+runpodctl <resource> --help               # actions + aliases
+runpodctl <resource> <action> --help      # exact flags, defaults, examples
+runpodctl help <resource> <action>        # same, and traverses aliases (`pod remove`) that --help does not
+runpodctl version                         # which surface you actually have
+```
+
+What lives here instead is the part `--help` never tells you: **what a flag means when it
+succeeds, what "ready" is defined as, which field to trust, and what a failure looks like.**
 Output shapes, error codes and env vars are in
 [output-and-errors.md](output-and-errors.md).
 
-## Pods
+> Two `--help` gotchas: cobra does **not** traverse aliases for `--help`, so `pod remove --help`
+> answers `unknown command` even though `pod remove <id>` works — use `runpodctl help pod remove`.
+> And the deprecated `get pod` / `get cloud` paths are hidden from `--help` but still live.
 
-```bash
-runpodctl pod list                                    # List running pods (default, like docker ps)
-runpodctl pod list --all                              # List all pods including exited
-runpodctl pod list --status exited                    # Filter by status (RUNNING, EXITED, etc.)
-runpodctl pod list --since 24h                        # Pods created within last 24 hours
-runpodctl pod list --created-after 2025-01-15         # Pods created after date
-runpodctl pod get <pod-id>                            # Get pod details (includes SSH info)
-runpodctl pod create --template-id runpod-torch-v21 --gpu-id "NVIDIA GeForce RTX 4090"  # From template
-runpodctl pod create --image "runpod/pytorch:..." --gpu-id "NVIDIA GeForce RTX 4090"    # From image
-runpodctl pod create --compute-type cpu --image ubuntu:22.04  # CPU pod (lowercase `cpu`)
-runpodctl pod start <pod-id>                          # Start stopped pod
-runpodctl pod stop <pod-id>                           # Stop running pod
-runpodctl pod restart <pod-id>                        # Restart pod
-runpodctl pod reset <pod-id>                          # Reset pod
-runpodctl pod update <pod-id> --name "new"            # Update pod
-runpodctl pod delete <pod-id>                         # Delete pod (aliases: rm, remove)
-runpodctl pod create --image <img> --gpu-id <id> --wait                  # wait until ssh answers (v2.9.0+)
-runpodctl pod create --image <img> --gpu-id <id> --wait --wait-timeout 3m # give up sooner than the 10m default
-```
+## Pods
 
 ### Waiting for readiness (`--wait`, v2.9.0+)
 
@@ -50,51 +44,23 @@ runpodctl pod create --image <img> --gpu-id <id> --wait --wait-timeout 3m # give
 | `runtimeStatusReason` | stable token when there is more to say, e.g. `awaiting_container`, `stopped_by_user`, `stopped_by_runpod`, `terminated_outbid`, `runtime_unavailable` |
 | `uptimeSeconds` | present only while the container is up; omitted otherwise (it used to be a constant `0`) |
 | `lastStatusChange` | the backend's raw free-text note, carried so a phrasing the cli does not tokenise still reaches you |
+| `networkVolumeId` | **v2.10.0+:** always present when the pod has a volume attached, with or without `--include-network-volume`; `--include-network-volume` additionally fills the full `networkVolume` object. On **v2.9.0 and earlier both were dropped on deserialization** and read back `null` even when a volume was attached — so a pre-v2.10.0 binary cannot be used to check whether a pod has one |
 
 `--status` filters **`desiredStatus` only** — `--status initializing` silently matches nothing.
 
-## Hub
+### Reading pod logs (`pod logs`, v2.10.0+)
 
-```bash
-runpodctl hub list                                    # Top 10 by stars
-runpodctl hub list --type SERVERLESS                  # Only serverless repos
-runpodctl hub list --type POD                         # Only pod repos
-runpodctl hub list --category ai --limit 20           # Filter by category
-runpodctl hub list --order-by deploys                 # Order by deploys
-runpodctl hub list --owner runpod-workers             # Filter by repo owner
-runpodctl hub search vllm                             # Search for "vllm"
-runpodctl hub search whisper --type SERVERLESS        # Search serverless repos
-runpodctl hub get <listing-id>                        # Get by listing id
-runpodctl hub get runpod-workers/worker-vllm          # Get by owner/name
-```
+| | detail |
+| --- | --- |
+| output | **json lines**, one `{source,line,ts}` object per line — pipe straight to `jq`, no SSE frame parsing |
+| `--source` | `container` (your workload's stdout/stderr), `system` (the platform narrating image pull, container create, start), or `both` (default) |
+| termination | without `--follow` it replays history and **exits on its own** once lines stop arriving (`--max-wait`, default `5s`, bounds the wait). With `--follow` it streams until interrupted and reconnects itself if the connection drops |
+| history | `--tail 0-5000` (default 100; `0` = live only), or `--since 30m|2h|7d|<rfc3339>`, which overrides `--tail` |
+| what to read it for | a stalled deploy is a `system` story — repeated pull progress, or a `create container` that never reaches `start` |
 
 ## Serverless (alias: sls)
 
-```bash
-runpodctl serverless list                             # List all endpoints
-runpodctl serverless get <endpoint-id>                # Get endpoint details
-runpodctl serverless create --name "x" --template-id "tpl_abc"  # Create from template
-runpodctl serverless create --name "x" --hub-id <listing-id>    # Create from hub repo
-runpodctl serverless create --hub-id <id> --env MODEL_NAME=my-model  # Override hub env defaults
-runpodctl serverless create --template-id <id> --gpu-id "NVIDIA GeForce RTX 4090" --model-reference https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct:main  # Attach & cache a HF model (GPU only)
-runpodctl serverless create --hub-id <id> --gpu-id "NVIDIA GeForce RTX 4090" --model-reference https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct:main       # Same, on a hub deploy
-runpodctl serverless create --compute-type CPU --template-id <id> --instance-id cpu3g-4-16  # CPU endpoint (uppercase `CPU`)
-runpodctl serverless create --template-id <t> --network-volume-ids <v1>,<v2> --data-center-ids <dc1>,<dc2>  # Multi-DC (v2.4.0+)
-runpodctl serverless update <endpoint-id> --workers-max 5       # Update endpoint
-runpodctl serverless delete <endpoint-id>             # Delete endpoint
-runpodctl serverless create --template-id <id> --workers-min 1 --wait  # wait for a ready worker (v2.9.0+)
-```
-
-### Invoking an endpoint (v2.9.0+)
-
-```bash
-runpodctl serverless run <endpoint-id> --input '{"prompt":"hi"}'   # submit + wait for the result
-runpodctl serverless run <endpoint-id> --input-file payload.json   # payload from a file ("-" = stdin)
-runpodctl serverless run <endpoint-id> --input '{}' --wait 15m     # wait budget (default 5m; 0 = do not wait)
-runpodctl serverless run <endpoint-id> --input '{}' --no-wait      # submit only (same as --wait 0)
-runpodctl serverless status <endpoint-id> <job-id>                 # poll a job submitted earlier
-runpodctl serverless health <endpoint-id>                          # worker + job counts
-```
+### Invoking an endpoint (`serverless run`, v2.9.0+)
 
 | | detail |
 | --- | --- |
@@ -106,6 +72,37 @@ runpodctl serverless health <endpoint-id>                          # worker + jo
 | two budgets | `--wait` bounds the whole job; the shared `timeout` config key (30s) bounds one api call. A call inside a wait is clamped to what is left, never below 1s |
 | `/run`, never `/runsync` | `/runsync` is not synchronous: the connection is released after ~90s with the job still running, no job id exists until it answers (so a slow response strands a billed, unpollable job), and a `sync-` job's result expires after 1 minute vs 30 for `/run` |
 
+`serverless status <endpoint-id> <job-id>` polls a job submitted earlier; `serverless health
+<endpoint-id>` returns worker + job counts.
+
+### Reading worker logs (`serverless logs`, v2.10.0+)
+
+Same flags and semantics as `pod logs` above, plus:
+
+| | detail |
+| --- | --- |
+| output | `{source,line,ts,workerId}` — the extra `workerId` is what makes the no-`--worker` form usable |
+| `--worker` | optional. **Omit it and the command resolves the endpoint's workers itself** and reads all of them at once, tagging each line. With `--follow` it also picks up workers that appear mid-run, so an endpoint scaling up does not need the command re-run |
+| what to read it for | the crash loop: repeated `system` `start container` lines with **no** `container` output means the container exits before the handler runs, which leaves jobs sitting in the queue with nothing wrong with capacity |
+
+### Endpoint update and zero values
+
+`serverless update` sends **zero values** as of **v2.10.0** (`--workers-min 0`,
+`--idle-timeout 0`, `--workers-max 0`, `--scaler-value 0`). On **v2.9.0 and earlier those were
+silently dropped** from the request, so resetting a dev endpoint back to scale-to-zero looked
+like it applied and the endpoint kept billing. On an older binary verify with `serverless get
+<id>`, or `PATCH https://rest.runpod.io/v1/endpoints/<id>` with an explicit `{"workersMin":0}`.
+
+`serverless update` has **no `--gpu-id` flag** — change an existing endpoint's GPU pool with
+that same `PATCH` and `{"gpuTypeIds":[...]}`.
+
+**Multi-DC** (`--network-volume-ids <v1>,<v2> --data-center-ids <dc1>,<dc2>`) needs
+**runpodctl ≥ v2.4.0**; data does not sync between volumes automatically — golden path
+[10](../../runpod/golden-paths/10-multi-region-ha-serverless.md).
+
+⚠️ `serverless get --include-workers` returns raw v1 worker records **including
+`RUNPOD_AI_API_KEY`/`RUNPOD_ENDPOINT_SECRET` in `env`** — don't paste its output into a ticket.
+
 ### Error codes worth branching on
 
 `timeout`, `job_failed`, `wait_timeout` and `wait_interrupted` are the codes these commands
@@ -114,89 +111,23 @@ add, and `not_found` gains a nuance during a wait. They live with every other co
 mean work outlived the cli, and the `id` field that names a resource a failed wait left
 behind.
 
-## Templates (alias: tpl)
+## Models
 
-```bash
-runpodctl template list                               # Official + community (first 10)
-runpodctl template list --type official               # All official templates
-runpodctl template list --type community              # Community templates (first 10)
-runpodctl template list --type user                   # Your own templates
-runpodctl template list --all                         # Everything including user
-runpodctl template list --limit 50                    # Show 50 templates
-runpodctl template search pytorch                     # Search for "pytorch" templates
-runpodctl template search comfyui --limit 5           # Search, limit to 5 results
-runpodctl template search vllm --type official        # Search only official
-runpodctl template get <template-id>                  # Get template details (README, env, ports)
-runpodctl template create --name "x" --image "img"    # Create template
-runpodctl template create --name "x" --image "img" --serverless  # Create serverless template
-runpodctl template update <template-id> --name "new"  # Update template
-runpodctl template delete <template-id>               # Delete template
-```
-
-## Network Volumes (alias: nv)
-
-```bash
-runpodctl network-volume list                         # List all volumes
-runpodctl network-volume get <volume-id>              # Get volume details
-runpodctl network-volume create --name "x" --size 100 --data-center-id "US-GA-1"  # Create volume
-runpodctl network-volume update <volume-id> --name "new"  # Update volume
-runpodctl network-volume delete <volume-id>           # Delete volume
-```
-
-## Models (Model Repository)
-
-```bash
-runpodctl model list                                  # List your models
-runpodctl model list --all                            # List all models (not just yours)
-runpodctl model list --name "llama"                   # Filter by name
-runpodctl model list --provider "meta"                # Filter by provider
-runpodctl model add --name "my-model" --model-path ./model   # Upload a local model dir (multipart)
-runpodctl model remove --name "my-model" --owner <owner>     # Remove a model
-```
-
-`model add` supports upload sessions, versioning, metadata, and private-source credentials —
-see live `runpodctl model add --help`. Concepts: [model-caching.md](model-caching.md).
-
-## Registry (alias: reg)
-
-```bash
-runpodctl registry list                               # List registry auths
-runpodctl registry get <registry-id>                  # Get registry auth
-runpodctl registry create --name "x" --username "u" --password "p"  # Create registry auth
-runpodctl registry delete <registry-id>               # Delete registry auth
-```
-
-## Info
-
-```bash
-runpodctl user                                        # Account info and balance (alias: me)
-runpodctl gpu list                                    # List available GPUs (+ $/hr per cloud + dataCenterAvailability[])
-runpodctl gpu list --include-unavailable              # Include unavailable GPUs
-runpodctl datacenter list                             # List datacenters (alias: dc)
-runpodctl billing pods                                # Pod billing history
-runpodctl billing serverless                          # Serverless billing history
-runpodctl billing network-volume                      # Volume billing history
-```
+`model add` supports upload sessions, versioning, metadata, and private-source credentials.
+Concepts: [model-caching.md](model-caching.md); flags: `runpodctl model add --help`.
 
 ## SSH
 
-```bash
-runpodctl ssh info <pod-id>                           # Get SSH info (command + key, does not connect)
-runpodctl ssh list-keys                               # List SSH keys
-runpodctl ssh add-key                                 # Add SSH key
-runpodctl ssh remove-key --name <name>                # Remove key by name
-runpodctl ssh remove-key --fingerprint <fp>           # Remove key by fingerprint (disambiguate shared names)
-```
+`ssh info <pod-id>` returns **connection details, not an interactive session** — and it has
+three output shapes, only one of which is an error. That table is in
+[output-and-errors.md](output-and-errors.md#parsing-ssh-info); read it before writing a
+readiness loop. If interactive SSH isn't available, execute remotely via
+`ssh user@host "command"`.
 
-`ssh info` returns connection details, not an interactive session. If interactive SSH isn't
-available, execute remotely via `ssh user@host "command"`.
+`ssh remove-key` takes `--name` **or** `--fingerprint`; use the fingerprint to disambiguate
+keys that share a name.
 
 ## File Transfer
-
-```bash
-runpodctl send <path>                                 # Send file/dir — prints a one-time code
-runpodctl receive <code>                              # Receive using that code (positional, no --code flag)
-```
 
 `send`/`receive` do encrypted, incremental, compressed transfer — don't pre-tar or
 pre-compress the source. **Agent flow (one side sends, the other receives):**
@@ -205,18 +136,30 @@ pre-compress the source. **Agent flow (one side sends, the other receives):**
    `send` then blocks until the receiver connects — so capture that first line as it streams
    (background the process, tee to a log) rather than waiting for exit.
 2. On the other machine (use `runpodctl ssh` into the pod/host if needed) run `receive <code>`
-   with that exact code. Each `send` mints a **fresh** code — never reuse or invent one.
+   with that exact code — positional, there is no `--code` flag. Each `send` mints a **fresh**
+   code — never reuse or invent one.
 3. Both processes must exit `0`. On failure, re-run `send` and use its **new** first-line code.
 
 To push local files to a pod: get `ssh info <pod-id>`, start `send` locally (capture the
 code), then `ssh` to the pod and run `receive <code>` there. For large/library-style data, a
 network volume or the S3 API is often simpler than `send`/`receive`.
 
-## Utilities
+## Hub, templates, volumes, registry, info, utilities
+
+Plain CRUD plus filters — `--help` is complete and this file would only go stale restating it:
 
 ```bash
-runpodctl doctor                                      # Diagnose and fix CLI issues (interactive)
-runpodctl update                                      # Update CLI to latest
-runpodctl version                                     # Show version
-runpodctl completion                                  # Auto-detect shell and install completion
+runpodctl hub --help              # list/search/get; --type, --category, --owner, --order-by
+runpodctl template --help         # list/search/get/create/update/delete; --type official|community|user
+runpodctl network-volume --help   # list/get/create/update/delete
+runpodctl registry --help         # list/get/create/delete
+runpodctl gpu list --help         # + $/hr per cloud and dataCenterAvailability[]
+runpodctl datacenter list --help  # alias: dc
+runpodctl billing --help          # pods / serverless / network-volume
+runpodctl user --help             # account + balance (alias: me)
+runpodctl doctor                  # interactive: diagnose and fix cli issues
+runpodctl completion              # auto-detect shell and install completion
 ```
+
+Which of these to reach for, and the traps that are not flags (Hub worker selection, CPU
+endpoints, template-vs-image, cost guards) are in the [SKILL.md](../SKILL.md) decision rules.

--- a/plugins/runpod/skills/runpodctl/reference/command-reference.md
+++ b/plugins/runpod/skills/runpodctl/reference/command-reference.md
@@ -24,7 +24,34 @@ runpodctl pod restart <pod-id>                        # Restart pod
 runpodctl pod reset <pod-id>                          # Reset pod
 runpodctl pod update <pod-id> --name "new"            # Update pod
 runpodctl pod delete <pod-id>                         # Delete pod (aliases: rm, remove)
+runpodctl pod create --image <img> --gpu-id <id> --wait                  # wait until ssh answers (v2.9.0+)
+runpodctl pod create --image <img> --gpu-id <id> --wait --wait-timeout 3m # give up sooner than the 10m default
 ```
+
+### Waiting for readiness (`--wait`, v2.9.0+)
+
+| | detail |
+| --- | --- |
+| ready means | the pod's **public port 22** accepts a tcp connection *and* answers with an ssh protocol banner. No key, no handshake — it proves sshd is up, not that your key is installed. Port 22 merely appearing in `runtime.ports` is not enough: prod allocates that port even for images that run no sshd |
+| timeout | `--wait-timeout` accepts `90s`, `10m`, `1h`, `2d`; default `10m` |
+| output | progress on **stderr** every ~15s; stdout stays exactly one json object, in the `pod get` shape (so it includes the live `ssh` block, unlike a plain create) |
+| on failure | the pod is **not** deleted — exit is non-zero, code `wait_timeout` (or `wait_interrupted` on ctrl-c), and the error object carries the pod id in `id` plus the delete command. A second ctrl-c always exits |
+| refuses | `--ssh=false` (there would be nothing to wait for) |
+| warns, still waits | `--compute-type CPU` (cpu pods are created over rest, which cannot request Runpod-managed ssh, so only an image that starts its own sshd becomes reachable) and `--cloud-type COMMUNITY` without `--public-ip` (community cloud only maps a public ssh port on a machine that has a public ip) |
+
+### Pod status fields
+
+`pod get` and `pod list` report both (v2.9.0+):
+
+| field | meaning |
+| --- | --- |
+| `desiredStatus` | what the platform intends: `RUNNING`, `EXITED`. Says `RUNNING` while the image is still pulling |
+| `runtimeStatus` | what is actually happening: `running`, `initializing` (no container reported yet — pull/create/boot), `stopped`, `terminated`, `unknown` (the runtime lookup failed or was not made — **not** "the pod is down") |
+| `runtimeStatusReason` | stable token when there is more to say, e.g. `awaiting_container`, `stopped_by_user`, `stopped_by_runpod`, `terminated_outbid`, `runtime_unavailable` |
+| `uptimeSeconds` | present only while the container is up; omitted otherwise (it used to be a constant `0`) |
+| `lastStatusChange` | the backend's raw free-text note, carried so a phrasing the cli does not tokenise still reaches you |
+
+`--status` filters **`desiredStatus` only** — `--status initializing` silently matches nothing.
 
 ## Hub
 
@@ -55,7 +82,37 @@ runpodctl serverless create --compute-type CPU --template-id <id> --instance-id 
 runpodctl serverless create --template-id <t> --network-volume-ids <v1>,<v2> --data-center-ids <dc1>,<dc2>  # Multi-DC (v2.4.0+)
 runpodctl serverless update <endpoint-id> --workers-max 5       # Update endpoint
 runpodctl serverless delete <endpoint-id>             # Delete endpoint
+runpodctl serverless create --template-id <id> --workers-min 1 --wait  # wait for a ready worker (v2.9.0+)
 ```
+
+### Invoking an endpoint (v2.9.0+)
+
+```bash
+runpodctl serverless run <endpoint-id> --input '{"prompt":"hi"}'   # submit + wait for the result
+runpodctl serverless run <endpoint-id> --input-file payload.json   # payload from a file ("-" = stdin)
+runpodctl serverless run <endpoint-id> --input '{}' --wait 15m     # wait budget (default 5m; 0 = do not wait)
+runpodctl serverless run <endpoint-id> --input '{}' --no-wait      # submit only (same as --wait 0)
+runpodctl serverless status <endpoint-id> <job-id>                 # poll a job submitted earlier
+runpodctl serverless health <endpoint-id>                          # worker + job counts
+```
+
+| | detail |
+| --- | --- |
+| payload | the **handler** payload, sent as `{"input": <your json>}`. Must be a json object; parsed and size-checked locally (the api's `/run` body limit is 10 MiB), so quoting mistakes and oversized bodies fail as `usage_error` before the upload |
+| `--input` vs `--input-file` | mutually exclusive; one is required. `-` reads stdin either way. A payload with its own top-level `input` key gets a warning — that is usually a whole curl envelope pasted in, which arrives double-wrapped |
+| stdout | always the job payload, including a `FAILED` job's `error`, and the last payload seen when the wait ran out. Printed byte-faithfully (handler keys are not renamed or re-typed) |
+| stderr | progress notes and the error object — never job data |
+| exit codes | `0` when `COMPLETED`, and when `--no-wait`/`--wait 0` submitted successfully. `1` on request failure, on wait-budget exhaustion (`timeout`), or on `FAILED`/`CANCELLED`/`TIMED_OUT` (`job_failed`) |
+| two budgets | `--wait` bounds the whole job; the shared `timeout` config key (30s) bounds one api call. A call inside a wait is clamped to what is left, never below 1s |
+| `/run`, never `/runsync` | `/runsync` is not synchronous: the connection is released after ~90s with the job still running, no job id exists until it answers (so a slow response strands a billed, unpollable job), and a `sync-` job's result expires after 1 minute vs 30 for `/run` |
+
+### Error codes worth branching on
+
+`timeout`, `job_failed`, `wait_timeout` and `wait_interrupted` are the codes these commands
+add, and `not_found` gains a nuance during a wait. They live with every other code in
+[output-and-errors.md](output-and-errors.md#codes) — including which are safe to retry, which
+mean work outlived the cli, and the `id` field that names a resource a failed wait left
+behind.
 
 ## Templates (alias: tpl)
 

--- a/plugins/runpod/skills/runpodctl/reference/output-and-errors.md
+++ b/plugins/runpod/skills/runpodctl/reference/output-and-errors.md
@@ -66,6 +66,12 @@ resource — so `if (status === 404)` misses every GraphQL not-found:
 output sink fills in a fallback when there isn't one — so local validation and transport
 failures carry a code too, not just API responses.
 
+**`timeout` is the one documented exception**, because two outcomes share it and only the
+message separates them (see the [codes table](#codes)). A handler that reads only `code` is
+still correct: treat `timeout` as never-retry and poll instead. Reading the message can
+upgrade that to "safe to retry" for the single-API-call case, but skipping it costs you
+nothing except an unnecessary poll — whereas retrying on the wrong one buys a second job.
+
 ### Codes
 
 | code | meaning |

--- a/plugins/runpod/skills/runpodctl/reference/output-and-errors.md
+++ b/plugins/runpod/skills/runpodctl/reference/output-and-errors.md
@@ -25,10 +25,28 @@ runpodctl pod list                    # json (default)
 runpodctl pod list --output=yaml      # yaml — the only alternative
 ```
 
-**There is no table format** — `json` and `yaml` are the only values, matched
-**case-sensitively**. An unrecognized value is not an error; it silently falls back to
-JSON, so `--output=table` *and* `--output=YAML` both return JSON. Pass lowercase `yaml` or
-don't pass the flag.
+**There is no table format** — `json` and `yaml` are the only values. As of **v2.10.0** an
+unrecognized value is a hard error before any API call, and matching is
+**case-insensitive**:
+
+```jsonc
+// runpodctl gpu list --output=table   (v2.10.0+)
+{"error":"invalid --output \"table\": supported formats are json and yaml","code":"usage_error"}
+// exit 1, usage text on stderr
+```
+
+```bash
+runpodctl gpu list --output=YAML      # v2.10.0+: real YAML (case is ignored)
+```
+
+⚠️ **This inverted in v2.10.0, so a handler has to know which binary it is on.** Through
+**v2.9.0** the flag was matched *case-sensitively* and anything unrecognized fell back to
+JSON **silently** — `--output=table` and `--output=YAML` both returned JSON, and the only
+safe advice was "pass lowercase `yaml` or don't pass the flag". That silence is how a table
+format the CLI never had ended up documented in the first place. On v2.10.0+ the same
+`--output=table` exits **1** with `usage_error`, so code that passed a defensive
+`--output=json` is fine but code passing anything else now fails loudly instead of
+degrading.
 
 (The legacy `get pod` / `get cloud` commands print a human table on stdout and ignore
 `--output` entirely — see [plaintext gaps](#plaintext-gaps).) Some commands print a human table on stdout regardless — the legacy
@@ -186,8 +204,8 @@ no `code`:
 | surface | shape |
 | --- | --- |
 | legacy `get`/`create`/`remove`/`start`/`stop pod`, `create`/`remove pods`, `get cloud` | `Error: <msg>` on stderr, exit 1 — including the missing-key case, which carries the same message as `no_credentials` but no JSON and no `code`. Success prints a human **table** on stdout, not JSON |
-| `exec` (hidden, deprecated) | progress on **stdout**, error plaintext on stderr, **exit 0**; polls up to **5 minutes** for the pod's SSH info before giving up |
-| `project` (hidden) | prints errors to **stdout** and exits **0** |
+| `exec` (hidden, deprecated) | **v2.10.0+:** joined the JSON error shape — flat JSON with a `code` on stderr and a **non-zero** exit. Through v2.9.0 it printed the error as plaintext and still exited **0**, so a caller that trusted the exit code saw a silent success. Either way: progress on **stdout**, and it polls up to **5 minutes** for the pod's SSH info before giving up |
+| `project` (hidden) | prints errors to **stdout** and exits **0** — the last surface where the exit code cannot be trusted |
 
 ### Parsing `ssh info`
 
@@ -216,9 +234,9 @@ ports that could never connect), and it drops out of `ssh connect`'s `connection
 which is now `[]` rather than `null` when nothing is reachable.
 
 So a parser should tolerate a non-JSON line on stderr from those, and must not rely on
-the exit code for `exec` or `project`. Prefer the non-legacy equivalents: `pod
-get`/`pod create`/`pod delete`, and `ssh info <pod-id>` + your own `ssh` invocation
-instead of `exec`.
+the exit code for `project` (nor for `exec` before v2.10.0). Prefer the non-legacy
+equivalents: `pod get`/`pod create`/`pod delete`, and `ssh info <pod-id>` + your own `ssh`
+invocation instead of `exec`.
 
 ## Environment variables
 

--- a/plugins/runpod/skills/runpodctl/reference/output-and-errors.md
+++ b/plugins/runpod/skills/runpodctl/reference/output-and-errors.md
@@ -49,6 +49,7 @@ Errors go to **stderr** as a single flat JSON object, and the exit code is
 | `error` | human-readable message, unwrapped on the REST path. A GraphQL HTTP failure whose body has no extractable message falls back to the **raw body**, which can itself be JSON — so never parse this field, either way |
 | `code` | stable, lowercase, present on every JSON error (see [plaintext gaps](#plaintext-gaps)) |
 | `status` | HTTP status — only when the failure arrived on a **non-2xx** response (REST *or* GraphQL) |
+| `id` | **v2.9.0+**, only on a failure that left a **created, billing resource** behind — a `create --wait` that timed out or was interrupted. Read it instead of regexing the message: it is the id you need to clean up |
 
 **Branch on `code`, never on `status` or the message text.** `status` is absent whenever
 the API answered HTTP 200 with empty data, which is how GraphQL reports a missing
@@ -70,12 +71,15 @@ failures carry a code too, not just API responses.
 | code | meaning |
 | --- | --- |
 | `usage_error` | unknown command, unknown flag, bad/wrong-count args, or a **cobra-required** flag left out. Usage text prints after the JSON |
-| `not_found` | the **API** does not have the resource |
+| `not_found` | the **API** does not have the resource. During a `create --wait` it can also mean one that *was* created has gone, or never became visible — so check for an `id` field before concluding nothing exists |
 | `bad_request` (400) `unauthorized` (401) `forbidden` (403) `conflict` (409) `rate_limited` (429) `server_error` (5xx) `api_error` | derived from the REST status |
 | `graphql_error` | a GraphQL call failed: an `errors` array in a 200 body, **or** a non-2xx response from the GraphQL endpoint (that form also carries `status`) |
 | `no_credentials` | no API key configured at all — set `RUNPOD_API_KEY` or run `runpodctl doctor` |
 | `network_error` | the API could not be reached at all — DNS, connection refused, TLS, timeout |
 | `cli_error` | anything else local: config, environment, and validation the command does itself |
+| `timeout` | **v2.9.0+.** The CLI stopped waiting — two outcomes sharing one code, told apart by the message. If it names a `serverless status` command, the **job is still running server-side**: poll it, never re-invoke (that buys a second job). Otherwise a single API call ran out of time and nothing is running, so a retry is fine |
+| `job_failed` | **v2.9.0+.** A serverless job reached a terminal status other than `COMPLETED` (`FAILED`/`CANCELLED`/`TIMED_OUT`). The request itself succeeded — the job payload, including the worker's own `error`, is still on **stdout** |
+| `wait_timeout` `wait_interrupted` | **v2.9.0+.** A `create --wait` gave up (budget) or was cancelled (ctrl-c / SIGTERM). The resource **was created and still bills**; its id is in the `id` field above |
 
 Treat this as **the set the CLI generates, not an exhaustive list** — an explicit code
 from the API is passed through lowercased, so a code outside the table can arrive from
@@ -91,7 +95,14 @@ wrapper does is all that happens.
   when `status` is 5xx). A transient `graphql_error` is possible too but indistinguishable
   from a permanent one, so cap those attempts tightly.
 - **Never retry:** `usage_error`, `cli_error`, `bad_request`, `not_found`, `conflict`,
-  `no_credentials`, `unauthorized`, `forbidden`.
+  `no_credentials`, `unauthorized`, `forbidden`, `job_failed` (the job ran and failed —
+  re-running is a new job, not a retry).
+- **Never retry the *command*, but do follow up:** `timeout` and
+  `wait_timeout`/`wait_interrupted` all mean work or a resource outlived the CLI. Re-running
+  the same command creates a **second** job or a **second** billed resource. Poll instead
+  (`serverless status`, `pod get`), or clean up using the `id` field. The one exception is a
+  `timeout` whose message does **not** name a follow-up command: that was a single API call
+  timing out with nothing left running, so it is safe to retry.
 
 Two invariants make that safe to encode:
 
@@ -99,8 +110,10 @@ Two invariants make that safe to encode:
   `--model-path`) is `cli_error`, so `not_found` never means "you typed a path wrong".
 - **`network_error` is the only code the CLI assigns to mean "couldn't reach the API"**,
   detected structurally. Deliberately *not* `network_error`: a malformed `RUNPOD_API_URL`
-  and a local wait loop timing out (e.g. `--wait-for-hash`) are both `cli_error`, so a
-  retry loop never fires for something a retry cannot fix.
+  is `cli_error`, so a retry loop never fires for something a retry cannot fix. A local wait
+  loop timing out used to land here too — as of **v2.9.0** `model add --wait-for-hash`
+  reports `timeout` instead of `cli_error` (same exit code, same message text), so a handler
+  switching on `code` needs that branch.
 
 ### Auth failures are two different codes
 
@@ -177,17 +190,24 @@ no `code`:
 | situation | output |
 | --- | --- |
 | connectable | `{"id","name","ssh_command","ip","port","ssh_key":{…}}` on stdout, exit 0 — note **snake_case**, unlike the camelCase everywhere else in the CLI. A `"setup":"runpodctl doctor"` key appears when the local key needs fixing |
-| pod exists, not connectable | `{"error":"pod not ready","id":…,"name":…,"status":…}` on **stdout**, exit **0**, no `code`. Here `status` is the pod's desired status, *not* an HTTP status |
+| pod exists, not connectable | `{"error":"pod not ready: <reason>","id":…,"name":…,"status":…}` on **stdout**, exit **0**, no `code`. Here `status` is the pod's desired status, *not* an HTTP status. **v2.9.0+** appends the reason (image still pulling, port 22 not published, pod stopped, …) — an exact-match `=== "pod not ready"` broke on that release, a prefix match did not |
 | no such pod | `{"error":"pod 'x' not found","code":"not_found"}` on stderr, exit 1 |
 
 So: check the exit code, then check for an `error` key even on stdout.
 
 "Not ready" fires whenever the pod has no **public port 22**, which is not the same thing
-as "still booting". A pod whose image never starts an sshd reports
-`{"error":"pod not ready","status":"RUNNING"}` indefinitely — verified by creating a
-`ubuntu:22.04` CPU pod and polling for ~70 s at `status: RUNNING` throughout. So **bound
-any SSH readiness loop** and don't treat `RUNNING` as "SSH is coming"; if it never arrives,
-the image is the problem, not the wait.
+as "still booting". A pod whose image never starts an sshd reports not-ready indefinitely —
+verified by creating a `ubuntu:22.04` CPU pod and polling for ~70 s at `status: RUNNING`
+throughout. So **bound any SSH readiness loop** and don't treat `RUNNING` as "SSH is
+coming"; if it never arrives, the image is the problem, not the wait.
+
+Two v2.9.0 changes make this easier to get right: `pod create --wait` does the bounded
+readiness loop for you (and proves an ssh *banner*, not just a published port), and
+`runtimeStatus` on `pod get`/`pod list` distinguishes `initializing` from `running` so you
+no longer have to infer it from `desiredStatus`. Also **v2.9.0+**: a **stopped** pod no
+longer returns an `ssh_command` at all (it used to hand back one built from stale runtime
+ports that could never connect), and it drops out of `ssh connect`'s `connections` list,
+which is now `[]` rather than `null` when nothing is reachable.
 
 So a parser should tolerate a non-JSON line on stderr from those, and must not rely on
 the exit code for `exec` or `project`. Prefer the non-legacy equivalents: `pod
@@ -199,6 +219,7 @@ instead of `exec`.
 | variable | default | what it sets |
 | --- | --- | --- |
 | `RUNPOD_API_KEY` | — | API key. Also settable via `runpodctl doctor` or `~/.runpod/config.toml` (`apikey`) |
+| `TIMEOUT` | `30s` | per-API-call deadline — **no `RUNPOD_` prefix** (the CLI reads env vars unprefixed, so this one looks nothing like the others). Exceeding it is `code: "timeout"`. Also settable as a top-level `timeout` in `~/.runpod/config.toml` — it must sit **above** any `[section]` header, or it becomes `section.timeout` and is silently ignored. Distinct from `--wait`, which bounds a whole job or readiness wait rather than one call |
 | `RUNPOD_API_URL` | `https://rest.runpod.io/v1` | REST control plane (config key `restApiUrl`) |
 | `RUNPOD_GRAPHQL_URL` | `https://api.runpod.io/graphql` | GraphQL control plane (config key `apiUrl`) |
 | `RUNPOD_INVOKE_URL` | `https://api.runpod.ai/v2` | base for the invoke URLs reported by `serverless create`/`get`/`list`/`update` (config key `invokeUrl`) |

--- a/plugins/runpod/skills/runpodctl/reference/output-and-errors.md
+++ b/plugins/runpod/skills/runpodctl/reference/output-and-errors.md
@@ -190,7 +190,7 @@ no `code`:
 | situation | output |
 | --- | --- |
 | connectable | `{"id","name","ssh_command","ip","port","ssh_key":{…}}` on stdout, exit 0 — note **snake_case**, unlike the camelCase everywhere else in the CLI. A `"setup":"runpodctl doctor"` key appears when the local key needs fixing |
-| pod exists, not connectable | `{"error":"pod not ready: <reason>","id":…,"name":…,"status":…}` on **stdout**, exit **0**, no `code`. Here `status` is the pod's desired status, *not* an HTTP status. **v2.9.0+** appends the reason (image still pulling, port 22 not published, pod stopped, …) — an exact-match `=== "pod not ready"` broke on that release, a prefix match did not |
+| pod exists, not connectable | `{"error":"pod not ready: <reason>","id":…,"name":…,"status":…}` on **stdout**, exit **0**, no `code`. Here `status` is the pod's desired status, *not* an HTTP status. **v2.9.0+** appends a reason when it has one (image still pulling, port 22 not published, pod stopped, …) and falls back to the bare `"pod not ready"` when it doesn't — so an exact-match `=== "pod not ready"` started failing intermittently on that release; a prefix match did not |
 | no such pod | `{"error":"pod 'x' not found","code":"not_found"}` on stderr, exit 1 |
 
 So: check the exit code, then check for an `error` key even on stdout.

--- a/testdata/runpodctl/command-surface.json
+++ b/testdata/runpodctl/command-surface.json
@@ -1,0 +1,726 @@
+{
+  "_comment": "Vendored runpodctl command surface. Regenerate with hooks/gen_cli_surface.py against a released binary. Gates hooks/check_cli_absence_claims.py.",
+  "commands": {
+    "billing": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "billing network-volume": {
+      "aliases": [
+        "network-volume",
+        "nv"
+      ],
+      "flags": [
+        "--bucket-size",
+        "--end-time",
+        "--help",
+        "--output",
+        "--start-time"
+      ]
+    },
+    "billing pods": {
+      "aliases": [],
+      "flags": [
+        "--bucket-size",
+        "--end-time",
+        "--gpu-id",
+        "--grouping",
+        "--help",
+        "--output",
+        "--pod-id",
+        "--start-time"
+      ]
+    },
+    "billing serverless": {
+      "aliases": [
+        "serverless",
+        "sls",
+        "endpoints"
+      ],
+      "flags": [
+        "--bucket-size",
+        "--end-time",
+        "--endpoint-id",
+        "--gpu-id",
+        "--grouping",
+        "--help",
+        "--output",
+        "--start-time"
+      ]
+    },
+    "datacenter": {
+      "aliases": [
+        "datacenter",
+        "dc",
+        "datacenters"
+      ],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "datacenter list": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "doctor": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "gpu": {
+      "aliases": [
+        "gpu",
+        "gpus"
+      ],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "gpu list": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--include-unavailable",
+        "--output"
+      ]
+    },
+    "hub": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "hub get": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "hub list": {
+      "aliases": [],
+      "flags": [
+        "--category",
+        "--help",
+        "--limit",
+        "--offset",
+        "--order-by",
+        "--order-dir",
+        "--output",
+        "--owner",
+        "--type"
+      ]
+    },
+    "hub search": {
+      "aliases": [],
+      "flags": [
+        "--category",
+        "--help",
+        "--limit",
+        "--offset",
+        "--order-by",
+        "--order-dir",
+        "--output",
+        "--owner",
+        "--type"
+      ]
+    },
+    "model": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "model add": {
+      "aliases": [],
+      "flags": [
+        "--content-type",
+        "--create-upload",
+        "--credential-reference",
+        "--credential-type",
+        "--file-name",
+        "--file-size",
+        "--hash-timeout",
+        "--help",
+        "--huggingface-model",
+        "--metadata",
+        "--model-path",
+        "--model-status",
+        "--name",
+        "--output",
+        "--owner",
+        "--part-size",
+        "--verbose",
+        "--wait-for-hash"
+      ]
+    },
+    "model list": {
+      "aliases": [
+        "list",
+        "ls"
+      ],
+      "flags": [
+        "--help",
+        "--name",
+        "--output",
+        "--provider"
+      ]
+    },
+    "model remove": {
+      "aliases": [
+        "remove",
+        "rm",
+        "delete"
+      ],
+      "flags": [
+        "--hash",
+        "--help",
+        "--name",
+        "--output",
+        "--owner",
+        "--version"
+      ]
+    },
+    "network-volume": {
+      "aliases": [
+        "network-volume",
+        "nv"
+      ],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "network-volume create": {
+      "aliases": [],
+      "flags": [
+        "--data-center-id",
+        "--help",
+        "--name",
+        "--output",
+        "--size"
+      ]
+    },
+    "network-volume delete": {
+      "aliases": [
+        "delete",
+        "rm",
+        "remove"
+      ],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "network-volume get": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "network-volume list": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "network-volume update": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--name",
+        "--output",
+        "--size"
+      ]
+    },
+    "pod": {
+      "aliases": [
+        "pod",
+        "pods"
+      ],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "pod create": {
+      "aliases": [],
+      "flags": [
+        "--cloud-type",
+        "--compliance",
+        "--compute-type",
+        "--container-disk-in-gb",
+        "--country-code",
+        "--data-center-ids",
+        "--docker-args",
+        "--env",
+        "--global-networking",
+        "--gpu-count",
+        "--gpu-id",
+        "--help",
+        "--image",
+        "--min-cuda-version",
+        "--name",
+        "--network-volume-id",
+        "--output",
+        "--ports",
+        "--public-ip",
+        "--registry-auth-id",
+        "--ssh",
+        "--stop-after",
+        "--template-id",
+        "--terminate-after",
+        "--type",
+        "--volume-in-gb",
+        "--volume-mount-path",
+        "--wait",
+        "--wait-timeout"
+      ]
+    },
+    "pod delete": {
+      "aliases": [
+        "delete",
+        "rm",
+        "remove"
+      ],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "pod get": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--include-machine",
+        "--include-network-volume",
+        "--output"
+      ]
+    },
+    "pod list": {
+      "aliases": [],
+      "flags": [
+        "--all",
+        "--compute-type",
+        "--created-after",
+        "--help",
+        "--name",
+        "--output",
+        "--since",
+        "--status"
+      ]
+    },
+    "pod logs": {
+      "aliases": [],
+      "flags": [
+        "--follow",
+        "--help",
+        "--max-wait",
+        "--output",
+        "--since",
+        "--source",
+        "--tail"
+      ]
+    },
+    "pod reset": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "pod restart": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "pod start": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "pod stop": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "pod update": {
+      "aliases": [],
+      "flags": [
+        "--container-disk-in-gb",
+        "--env",
+        "--help",
+        "--image",
+        "--name",
+        "--output",
+        "--ports",
+        "--volume-in-gb",
+        "--volume-mount-path"
+      ]
+    },
+    "receive": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "registry": {
+      "aliases": [
+        "registry",
+        "reg"
+      ],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "registry create": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--name",
+        "--output",
+        "--password",
+        "--username"
+      ]
+    },
+    "registry delete": {
+      "aliases": [
+        "delete",
+        "rm",
+        "remove"
+      ],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "registry get": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "registry list": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "send": {
+      "aliases": [],
+      "flags": [
+        "--code",
+        "--help",
+        "--output"
+      ]
+    },
+    "serverless": {
+      "aliases": [
+        "serverless",
+        "sls"
+      ],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "serverless create": {
+      "aliases": [],
+      "flags": [
+        "--compute-type",
+        "--data-center-ids",
+        "--env",
+        "--execution-timeout",
+        "--flash-boot",
+        "--gpu-count",
+        "--gpu-id",
+        "--help",
+        "--hub-id",
+        "--idle-timeout",
+        "--instance-id",
+        "--min-cuda-version",
+        "--model-reference",
+        "--name",
+        "--network-volume-id",
+        "--network-volume-ids",
+        "--output",
+        "--scale-by",
+        "--scale-threshold",
+        "--template-id",
+        "--wait",
+        "--wait-timeout",
+        "--workers-max",
+        "--workers-min"
+      ]
+    },
+    "serverless delete": {
+      "aliases": [
+        "delete",
+        "rm",
+        "remove"
+      ],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "serverless get": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--include-template",
+        "--include-workers",
+        "--output"
+      ]
+    },
+    "serverless health": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "serverless list": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--include-template",
+        "--include-workers",
+        "--output"
+      ]
+    },
+    "serverless logs": {
+      "aliases": [],
+      "flags": [
+        "--follow",
+        "--help",
+        "--max-wait",
+        "--output",
+        "--since",
+        "--source",
+        "--tail",
+        "--worker"
+      ]
+    },
+    "serverless run": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--input",
+        "--input-file",
+        "--no-wait",
+        "--output",
+        "--wait"
+      ]
+    },
+    "serverless status": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--no-wait",
+        "--output",
+        "--wait"
+      ]
+    },
+    "serverless update": {
+      "aliases": [],
+      "flags": [
+        "--clear-models",
+        "--help",
+        "--idle-timeout",
+        "--model-reference",
+        "--name",
+        "--output",
+        "--scale-by",
+        "--scale-threshold",
+        "--template-id",
+        "--workers-max",
+        "--workers-min"
+      ]
+    },
+    "ssh": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "ssh add-key": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--key",
+        "--key-file",
+        "--output"
+      ]
+    },
+    "ssh info": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--output",
+        "--verbose"
+      ]
+    },
+    "ssh list-keys": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "ssh remove-key": {
+      "aliases": [],
+      "flags": [
+        "--fingerprint",
+        "--help",
+        "--name",
+        "--output"
+      ]
+    },
+    "template": {
+      "aliases": [
+        "template",
+        "tpl",
+        "templates"
+      ],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "template create": {
+      "aliases": [],
+      "flags": [
+        "--container-disk-in-gb",
+        "--docker-entrypoint",
+        "--docker-start-cmd",
+        "--env",
+        "--help",
+        "--image",
+        "--name",
+        "--output",
+        "--port-labels",
+        "--ports",
+        "--readme",
+        "--registry-auth-id",
+        "--serverless",
+        "--volume-in-gb",
+        "--volume-mount-path"
+      ]
+    },
+    "template delete": {
+      "aliases": [
+        "delete",
+        "rm",
+        "remove"
+      ],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "template get": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "template list": {
+      "aliases": [],
+      "flags": [
+        "--all",
+        "--help",
+        "--limit",
+        "--offset",
+        "--output",
+        "--type"
+      ]
+    },
+    "template search": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--limit",
+        "--offset",
+        "--output",
+        "--type"
+      ]
+    },
+    "template update": {
+      "aliases": [],
+      "flags": [
+        "--container-disk-in-gb",
+        "--env",
+        "--help",
+        "--image",
+        "--name",
+        "--output",
+        "--port-labels",
+        "--ports",
+        "--readme",
+        "--registry-auth-id"
+      ]
+    },
+    "update": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "user": {
+      "aliases": [
+        "user",
+        "account",
+        "me"
+      ],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    },
+    "version": {
+      "aliases": [],
+      "flags": [
+        "--help",
+        "--output"
+      ]
+    }
+  },
+  "hidden_commands": [
+    "get pod",
+    "get cloud",
+    "create pod",
+    "remove pod",
+    "exec",
+    "project",
+    "config"
+  ],
+  "version": "runpodctl 2.10.0-fc93344"
+}


### PR DESCRIPTION
runpodctl [v2.10.0](https://github.com/runpod/runpodctl/releases/tag/v2.10.0) shipped `pod logs` and `serverless logs`. This PR started life covering [v2.9.0](https://github.com/runpod/runpodctl/releases/tag/v2.9.0) and asserting — in eleven places, including a new eval — that **worker logs were MCP-only**. That half is now false, so the interesting content here is the corrections, not the additions.

## What v2.10.0 forced

- **`pod logs` / `serverless logs` exist** (`--follow`, `--tail`, `--since`, `--source`, `--worker`; json lines, not SSE). Eleven assertions across five files said otherwise. The worst was `route-serverless-observability.eval.md`, which graded an agent **correct** for answering *"worker logs → NOT runpodctl … the MCP lane is the only one that can read them."* A false negative in an eval trains the wrong behavior in rather than merely misinforming a reader — rewritten to expect `serverless logs`, SSE demoted to the pre-v2.10.0 fallback. Golden path 15 §3 is restructured: CLI is Route A, raw v2 REST is B, MCP is C. `stream-job` is now the only genuinely MCP-only capability.
- **`--output` inverted.** The reference said matching is case-sensitive and unrecognized values silently return JSON, so `--output=table` and `--output=YAML` both give JSON. On v2.10.0 `table` exits 1 with `usage_error` before any API call, and `YAML` returns real YAML. Both halves backwards; both behaviors now recorded, since a handler has to know which binary it's on.
- **`exec` exits non-zero now** and emits coded JSON, leaving `project` as the only surface where the exit code can't be trusted. The error-handling eval asserted the old grouping.
- **`--workers-min 0` was a silent no-op before v2.10.0** (#313 — `omitempty` ate the zero). The SKILL.md instruction to reset a dev endpoint back to scale-to-zero looked like it applied while the endpoint kept billing. Cost-safety claim, now version-floored.
- **`pod get` returns `networkVolumeId`** as of #322; earlier binaries dropped it and read back `null`, so they can't answer "does this pod have a volume".

## Additions (the original v2.9.0 scope)

`serverless run`/`status`/`health`, `--wait`/`--wait-timeout` on both creates, `runtimeStatus`/`runtimeStatusReason`/`uptimeSeconds` on `pod get`/`list`, and the `timeout`/`job_failed`/`wait_timeout`/`wait_interrupted` codes plus the `id` field, folded into the existing code table. Two evals (`serverless-invoke-job`, `create-and-wait-until-usable`), each asserting the negative as well as the positive.

## Stopping the recurrence

Absence claims are the one kind that rots silently — `--help` deference doesn't protect them, because there's no flag to look up, so nobody reverifies. This is the **second** time: v2.9.0 added `serverless health` (falsifying "diagnosis relies on `/health` counts"), v2.10.0 added the log commands.

So it's gated, following the precedent rule 8 already sets for runpod-migrate's Class-3 table:

- `testdata/runpodctl/command-surface.json` — 66 commands walked out of the v2.10.0 binary, plus the paths cobra hides from `--help`.
- `hooks/check_cli_absence_claims.py` — blocking in `validate.yml` against the snapshot; `--live` weekly in `spec-drift.yml`, which is what would have caught this PR on the day.
- `hooks/gen_cli_surface.py` — regenerates the snapshot against any binary.
- New AGENTS.md **rule 9**: prefer a positive claim or a version floor over an open-ended "cannot", and never put a false negative in an eval.

Deliberately narrow, because a noisy gate gets disabled: missing-*flag* claims are exempt (`--help` covers those), so are negated and version-floored phrasings, and true absences need an `ALLOW` entry with a reason.

## Also

`reference/command-reference.md` 222 → 165 lines. It opened by admitting `--help` is authoritative, then spent 140 lines restating it — hand-copied flag lists for Hub, templates, volumes, registry, info, utilities. Kept only what `--help` can't tell you (what "ready" means for `--wait`, which pod status field to trust, the `serverless run` exit-code contract, the `send`/`receive` code flow, the `--include-workers` secret leak); everything mechanical is a pointer at the binary.

## Source of truth

The lanes wrap tools on their own release trains, so the router now says so up front: take
capability and syntax from `runpodctl --help` / the client's tool list / `openapi.json`, not from
these files, and never assert a tool *cannot* do something without checking. `command-reference.md`
follows the same rule — it holds only what `--help` cannot answer. `flash` and `companion-clis` say
the same about their own tools. `no-unchecked-absence-claims.eval.md` writes the expectation down,
prompting for the exact question this PR originally got wrong.

## Routing: golden paths were structurally unreachable

Separate problem, same root cause — the docs described a thing the reader never got to. The
router put lane selection first, said "read the matching skill's `SKILL.md` next", and listed the
worked examples 67 lines later, so an agent following the instructions handed off to a lane before
seeing them. Three of six lanes never mentioned golden paths at all, and neither did the
frontmatter `description` — the only part always in context.

Now: **step 0 of "How to route"**, ahead of lane selection, triggered on observable properties
(more than one resource or lane, provisions something billable, "get X running", or worth a
multi-step plan) with an explicit skip for single reads and single CRUD calls. A matching path
outranks the lane table, since it was verified end to end on a real account. Every lane links
back. Partial matches count.

Also fixes drift the new rule forbids: **path 21 had no router row**, so routing could not reach
it. `consult-golden-path-first.eval.md` documents both directions — a one-line `stop pod` must
*not* open a path; a host-cached HF deploy must find path 20 specifically before proposing
commands.

### Validated against a control, not just specified

Nothing in this repo executes `evals/*.eval.md` (no runner, CI does not read them), so the routing
change was measured by hand instead: same prompts against `origin/main` and this branch, agents
reporting which files they opened and in what order.

**Router entry: no effect.** 4/4 agents opened golden path 20 in both arms — the "Want to…" table
already has a near-verbatim row and agents read the file end to end. Said so in the eval rather than
leaving a weak test looking like coverage.

**Lane entry (the realistic case — an agent already in a lane does not re-read the router), task
with no verbatim row, 3-DC HA endpoint:**

| | opened a path | plan source | one endpoint + per-DC volumes |
| --- | --- | --- | --- |
| `origin/main` | 0 / 2 | derived | 0 / 2 |
| this branch | 2 / 2, before planning | golden-path | 2 / 2 |

Both treatment runs cited the added pointer by name and found path 19 — a closer match than the
path 10 the eval predicted. Both control runs, lacking the example, **invented a limitation** to
justify the plan they derived: *"you cannot attach one network volume to a multi-DC endpoint"* and
*"network volumes are not a mechanism for multi-DC redundancy"*. Path 10 live-verified the opposite
on 2026-07-10. That is the same defect class as the docs bug the CI gate above stops, arriving from
the other direction — the gate stops the repo asserting a false absence; surfacing the examples
stops a model inventing one.

<details><summary>Verification</summary>

Everything checked against the **shipped v2.10.0 binary**, plus v2.9.0 for the before/after claims. An independent pass re-checked every claim adversarially and corrected three of mine (see below).

- `pod logs` / `serverless logs` flag surface and defaults from live `--help`; absent on v2.9.0.
- `--output`: `table`/`TABLE`/`xml` → `usage_error` exit 1 on v2.10.0, JSON on v2.9.0. `YAML` → real YAML on v2.10.0, JSON on v2.9.0.
- v2.9.0 vs v2.10.0 `--help` diffed across all 18 commands the skills exercise — byte-identical apart from the two new `logs` commands. No undocumented flag drift.
- #313/#322/#319 confirmed from the merged upstream diffs, not the changelog lines.
- #303 (self-update checksums) falsifies nothing — the skills make no claims about signing or asset selection.
- Every `runpodctl <resource> <action>` in the skills resolves against the real v2.10.0 command tree; all aliases used (`sls`, `nv`, `tpl`, `reg`, `dc`, `me`, `pod remove`) are real.
- Gate verified both ways: reintroducing this branch's own "runpodctl still has no serverless logs command" fails it; the 16 legitimate absence claims pass. `--live` resolved v2.10.0 from the GitHub API.
- All 8 repo gates pass.

Corrections from the independent pass, all taken: the count was 11 across 5 files (not ~15); the eval was ~1/3 false (not wholly), so step 3 was rewritten rather than the file deleted; and `pod remove --help` returns `unknown command` because cobra doesn't traverse aliases for `--help` — the right check is `runpodctl help pod remove`. That trap is now documented, since the same method would have wrongly condemned the live-but-hidden `get pod` / `get cloud`.

Not verified at runtime (no cost incurred): the `job_failed` code and the `timeout`-names-a-follow-up message need a real job to fail or stall; the `id` field needs a real `--wait` to time out; the `serverless logs` output shape is taken from the binary's interface rather than a fresh live capture (the captured frames in golden path 15 are the 2026-08-06 SSE run against the identical upstream service).

</details>

No version bumps — release-please owns those (AGENTS.md rule 10).





