### PR TITLE
fix(release): register runpod-migrate with release-please

### DIFF
--- a/hooks/check_versions.py
+++ b/hooks/check_versions.py
@@ -34,6 +34,26 @@ for skill in sorted(ROOT.glob("plugins/runpod/skills/*/SKILL.md")):
     m = _VER_RE.search(skill.read_text())
     seen[str(skill.relative_to(ROOT))] = m.group(1) if m else None
 
+# A skill release-please does not know about never gets bumped, so the next
+# release PR fails this check instead of the PR that added the skill. Catch it
+# where it is cheap to fix.
+config = json.loads((ROOT / "release-please-config.json").read_text())
+registered = {
+    entry if isinstance(entry, str) else entry["path"]
+    for entry in config["packages"]["."]["extra-files"]
+}
+unregistered = sorted(
+    str(skill.relative_to(ROOT))
+    for skill in ROOT.glob("plugins/runpod/skills/*/SKILL.md")
+    if str(skill.relative_to(ROOT)) not in registered
+)
+if unregistered:
+    print("version check FAILED — skills missing from release-please-config.json:")
+    for f in unregistered:
+        print(f"  {f}")
+    print("Add each to packages['.'].extra-files, or release-please will not bump it.")
+    sys.exit(1)
+
 vals = set(seen.values())
 if None in vals or len(vals) != 1:
     print("version check FAILED — versions disagree:")

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -25,6 +25,7 @@
         { "type": "json", "path": ".claude-plugin/marketplace.json", "jsonpath": "$.version" },
         "plugins/runpod/skills/runpod/SKILL.md",
         "plugins/runpod/skills/runpod-mcp/SKILL.md",
+        "plugins/runpod/skills/runpod-migrate/SKILL.md",
         "plugins/runpod/skills/runpodctl/SKILL.md",
         "plugins/runpod/skills/flash/SKILL.md",
         "plugins/runpod/skills/companion-clis/SKILL.md",


### PR DESCRIPTION
Unblocks the failing version check on release PR #47.

## What broke

`hooks/check_versions.py` **globs** every `plugins/runpod/skills/*/SKILL.md`. release-please only bumps files **enumerated** in `release-please-config.json` → `extra-files`. #46 added `runpod-migrate` without registering it there, so the 1.2.0 release PR bumped everything except the one skill that merge introduced:

```
1.2.0  ...every other manifest and skill
1.1.2  plugins/runpod/skills/runpod-migrate/SKILL.md
```

Not a release-please bug and not a bad guard — the two just disagree about how the skill list is discovered.

## Fix

1. Register `plugins/runpod/skills/runpod-migrate/SKILL.md` in `extra-files`.
2. Make the guard assert that every skill it globs is registered, naming any that are not. Without this, the next unregistered skill again fails the *following* release PR instead of the PR that added it — a failure far from its cause.

## To land it

Merge this, then let release-please regenerate #47 (or close and reopen it). The refreshed PR will bump `runpod-migrate` with everything else and the check will pass.

<details>
<summary>Verification</summary>

- `python3 hooks/check_versions.py` → `version check OK — all manifests + skills at 1.1.2`.
- Removed the new entry again in a scratch copy to confirm the added check is not vacuous:

```
version check FAILED — skills missing from release-please-config.json:
  plugins/runpod/skills/runpod-migrate/SKILL.md
Add each to packages['.'].extra-files, or release-please will not bump it.
```
</details>