### PR TITLE
docs(runpodctl): document secure registry password input

### DIFF
--- a/plugins/runpod/skills/runpodctl/evals/registry-password-stdin.eval.md
+++ b/plugins/runpod/skills/runpodctl/evals/registry-password-stdin.eval.md
@@ -1,0 +1,27 @@
+# Create a registry auth without exposing its token
+
+## Prompt
+
+I have a private registry token in `REGISTRY_TOKEN`. Create a Runpod registry auth
+named `ghcr` for username `octocat`, but do not put the token in command arguments
+or shell history.
+
+## Expected behavior
+
+The agent should:
+
+1. Use `runpodctl registry create` with `--password-stdin`
+2. Pipe the environment variable through stdin without expanding its value into the
+   runpodctl argument list
+3. Keep `--name ghcr` and `--username octocat` on the command
+4. Avoid `--password`, because that exposes the credential through `argv`
+5. Recognize that omitting both password flags is appropriate only for a human at an
+   interactive no-echo prompt, not for an automated command
+
+## Assertions
+
+- Uses `runpodctl registry create --name ghcr --username octocat --password-stdin`
+- Pipes `REGISTRY_TOKEN` into stdin, for example with `printenv REGISTRY_TOKEN`
+- Does NOT use `--password "$REGISTRY_TOKEN"` or place the token value in any argument
+- Does NOT tell an automated caller to rely on the interactive prompt
+- Does NOT write the token to a temporary file

--- a/plugins/runpod/skills/runpodctl/reference/command-reference.md
+++ b/plugins/runpod/skills/runpodctl/reference/command-reference.md
@@ -118,7 +118,7 @@ Concepts: [model-caching.md](model-caching.md); flags: `runpodctl model add --he
 
 ## Registry credentials
 
-Prefer `registry create --password-stdin` for scripts so the credential does not enter the
+Prefer `registry create --password-stdin` (needs **v2.11.0+**) for scripts so the credential does not enter the
 process table or shell history. A secret already held in an environment variable can be piped
 without expanding its value into the runpodctl argument list:
 

--- a/plugins/runpod/skills/runpodctl/reference/command-reference.md
+++ b/plugins/runpod/skills/runpodctl/reference/command-reference.md
@@ -116,6 +116,25 @@ behind.
 `model add` supports upload sessions, versioning, metadata, and private-source credentials.
 Concepts: [model-caching.md](model-caching.md); flags: `runpodctl model add --help`.
 
+## Registry credentials
+
+Prefer `registry create --password-stdin` for scripts so the credential does not enter the
+process table or shell history. A secret already held in an environment variable can be piped
+without expanding its value into the runpodctl argument list:
+
+```bash
+printenv REGISTRY_TOKEN | runpodctl registry create --name "x" --username "u" --password-stdin
+```
+
+Redirecting a credential file to `--password-stdin` also works, including multi-line
+credentials such as a GCR service-account JSON key. The command strips one trailing line
+ending but preserves leading, inner, and other trailing whitespace.
+
+`--password` remains supported for compatibility, but places the credential in `argv`.
+When neither password flag is present and stdin is a terminal, runpodctl prompts without
+echo. With non-terminal stdin and no password source it returns `usage_error` instead of
+blocking; `--password` and `--password-stdin` are mutually exclusive.
+
 ## SSH
 
 `ssh info <pod-id>` returns **connection details, not an interactive session** — and it has


### PR DESCRIPTION
Companion to https://github.com/runpod/runpodctl/pull/329.

> **Merge condition met (2026-08-20):** runpodctl v2.11.0 containing #329 is published as `latest`, the documented **v2.11.0+** floor matches, and `testdata/runpodctl/command-surface.json` is regenerated against the v2.11.0 binary. Ready to leave draft.

## What changed

- documents `registry create --password-stdin` as the preferred scripted path
- shows how to pipe an environment-held token without putting its value in `argv`
- documents the no-echo interactive prompt, non-interactive failure behavior, mutually exclusive flags, and multi-line credential handling
- adds a regression eval that rejects `--password "$REGISTRY_TOKEN"` for a caller that explicitly asks not to expose the token

## Why

runpodctl#329 adds secure password input through stdin and an interactive prompt. The runpodctl repository requires its skill to stay synchronized whenever commands, flags, or behavior change.

## Validation

- marketplace manifest validation
- version consistency check
- Runpod branding check
- Markdown link check
- CLI absence-claim self-test and repository check
- runpod-migrate scanner and spec-table checks
- `git diff --check`


## Tracking

- [CON-1156](https://linear.app/runpod/issue/CON-1156/runpodctl-read-registry-passwords-securely-from-stdin-or-a-prompt)

---

## Related PRs

Two independent groups. Nothing in one blocks anything in the other.

### Group A — the Windows install command (runpod/runpodctl#311)

One broken command that had been copy-pasted into three repos. Each PR fixes its own copy; **any order, no dependencies.**

| PR | Repo | Change |
|---|---|---|
| runpod/runpodctl#328 | runpodctl | `README.md` — fix the command, and install to `PATH` |
| runpod/docs#805 | docs | `runpodctl/overview.mdx` — same fix on docs.runpod.io |
| runpod/runpod-plugins-official#49 | plugins | delete `reference/install.md`, the third copy |

### Group B — secure registry passwords (runpod/runpodctl#327)

**Order matters.** #51 documents a flag that does not exist on `main` until #329 merges, so it stays draft until then.

| # | PR | Repo | Change |
|---|---|---|---|
| 1 | runpod/runpodctl#329 | runpodctl | `--password-stdin`, no-echo prompt, mutually exclusive flags |
| 2 | runpod/runpod-plugins-official#51 ← **this PR** | plugins | skill guidance + regression eval (**draft** until #329 lands) |

The only thing the two groups share is that both touched the runpodctl skill, which is what prompted Group A's deletion: the skill had been keeping its own copy of install instructions the runpodctl README already owned.

